### PR TITLE
Fix renamed fields in the party equipment data collection.

### DIFF
--- a/client/GameData/Party/DataEquipmentInformation.cs
+++ b/client/GameData/Party/DataEquipmentInformation.cs
@@ -56,19 +56,19 @@ namespace FFRKInspector.GameData.Party
         [JsonProperty("mnd")]
         public short Mnd;
 
-        [JsonProperty("series_atk")]
+        [JsonProperty("sp_atk")]
         public short SeriesAtk;
-        [JsonProperty("series_matk")]
+        [JsonProperty("sp_matk")]
         public short SeriesMag;
-        [JsonProperty("series_acc")]
+        [JsonProperty("sp_acc")]
         public short SeriesAcc;
-        [JsonProperty("series_def")]
+        [JsonProperty("sp_def")]
         public short SeriesDef;
-        [JsonProperty("series_mdef")]
+        [JsonProperty("sp_mdef")]
         public short SeriesRes;
-        [JsonProperty("series_eva")]
+        [JsonProperty("sp_eva")]
         public short SeriesEva;
-        [JsonProperty("series_mnd")]
+        [JsonProperty("sp_mnd")]
         public short SeriesMnd;
 
         [JsonProperty("category_id")]


### PR DESCRIPTION
The code refers to `series_atk`, `series_matk`, etc. for synergy stats on equipment, but I believe those fields were renamed to `sp_atk` and so forth. This fixes parts of the inventory tab when changing realm synergy.
