### PR TITLE
Magicite issues in database

### DIFF
--- a/client/Database/DbOpRecordBattleEncounter.cs
+++ b/client/Database/DbOpRecordBattleEncounter.cs
@@ -29,7 +29,7 @@ namespace FFRKInspector.Database
             foreach (BasicEnemyInfo enemy in mEncounter.Battle.Enemies)
                 CallProcInsertEnemyEntry(connection, transaction, enemy.EnemyId, enemy.EnemyName);
 
-            var non_gold_drop_events = drops.Where(x => x.ItemType == DataEnemyDropItem.DropItemType.Equipment || x.ItemType == DataEnemyDropItem.DropItemType.Orb);
+            var non_gold_drop_events = drops.Where(x => x.ItemType == DataEnemyDropItem.DropItemType.Equipment || x.ItemType == DataEnemyDropItem.DropItemType.Orb || x.ItemType == DataEnemyDropItem.DropItemType.Magicite);
             // Record per-enemy drops
             foreach (DropEvent drop in non_gold_drop_events)
                 CallProcRecordDropsForBattleAndEnemy(connection, transaction, mEncounter.Battle.BattleId, drop);

--- a/client/Database/DbOpRecordBattleEncounter.cs
+++ b/client/Database/DbOpRecordBattleEncounter.cs
@@ -80,7 +80,7 @@ namespace FFRKInspector.Database
                 command.Parameters.AddWithValue("@battle_id", battle_id);
                 command.Parameters.AddWithValue("@item_id", drop.ItemId);
                 command.Parameters.AddWithValue("@enemy_id", drop.EnemyId);
-                command.Parameters.AddWithValue("@item_count", 1);
+                command.Parameters.AddWithValue("@item_count", drop.NumberOfItems);
                 return command.ExecuteNonQuery();
             }
         }


### PR DESCRIPTION
I was looking at the FFRKI tables, querying for Magicite drops. The results did not pass a sanity check (much too low). In addition, the per_enemy_drops have all had histo_bucket set to 1. I may have an error in the 2nd commit since I don't understand why it was hardcoded to 1 in the first place - please review that.  

Also, since there is _some_ Magicite recorded in the database then I think someone must be running a variant of FFRKI that includes my first commit.
