### PR TITLE
Party planner equipment grid

### DIFF
--- a/client/FFRKInspector.csproj
+++ b/client/FFRKInspector.csproj
@@ -84,7 +84,6 @@
     <Compile Include="DataCache\Worlds.cs" />
     <Compile Include="EquipmentStatsDataSet.cs">
       <DependentUpon>EquipmentStatsDataSet.xsd</DependentUpon>
-      <SubType>Component</SubType>
     </Compile>
     <Compile Include="EquipmentStatsDataSet.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/client/FFRKInspector.csproj
+++ b/client/FFRKInspector.csproj
@@ -846,8 +846,15 @@
     <Compile Include="UI\DatabaseUI\MissingItemsPanel.Designer.cs">
       <DependentUpon>MissingItemsPanel.cs</DependentUpon>
     </Compile>
+    <Compile Include="UI\SavedPartyData.cs" />
     <Compile Include="UI\SeriesDataGridViewCell.cs" />
     <Compile Include="Analyzer\AnalyzerSettings.cs" />
+    <Compile Include="UI\TextInput.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UI\TextInput.Designer.cs">
+      <DependentUpon>TextInput.cs</DependentUpon>
+    </Compile>
     <Compile Include="Utility\CriticalZ.cs" />
     <Compile Include="Utility\Histogram.cs" />
     <Compile Include="Utility\IConverter.cs" />
@@ -903,6 +910,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="UI\ListViewEx.resx">
       <DependentUpon>ListViewEx.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UI\TextInput.resx">
+      <DependentUpon>TextInput.cs</DependentUpon>
     </EmbeddedResource>
     <None Include="app.config" />
     <None Include="EquipmentStatsDataSet.xsc">

--- a/client/FFRKInspector.csproj
+++ b/client/FFRKInspector.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -117,6 +117,7 @@
     <Compile Include="GameData\Abilities\Chakra.cs" />
     <Compile Include="GameData\Abilities\ChiBlast.cs" />
     <Compile Include="GameData\Abilities\Chocobo.cs" />
+    <Compile Include="GameData\Abilities\ConfuseShell.cs" />
     <Compile Include="GameData\Abilities\Cry.cs" />
     <Compile Include="GameData\Abilities\DaggerToss.cs" />
     <Compile Include="GameData\Abilities\DarkAttack.cs" />
@@ -349,6 +350,7 @@
     <Compile Include="GameData\RecordMaterias\CetrasDestiny.cs" />
     <Compile Include="GameData\RecordMaterias\ConcertMusician.cs" />
     <Compile Include="GameData\RecordMaterias\CulturedConjurer.cs" />
+    <Compile Include="GameData\RecordMaterias\DesertBloom.cs" />
     <Compile Include="GameData\RecordMaterias\Devotion.cs" />
     <Compile Include="GameData\RecordMaterias\DragoonsDetermination.cs" />
     <Compile Include="GameData\RecordMaterias\EidolonsBond.cs" />
@@ -395,6 +397,7 @@
     <Compile Include="GameData\RecordMaterias\RodMaster.cs" />
     <Compile Include="GameData\RecordMaterias\RonsoPride.cs" />
     <Compile Include="GameData\RecordMaterias\SelfSacrifice.cs" />
+    <Compile Include="GameData\RecordMaterias\ShieldOfDalmasca.cs" />
     <Compile Include="GameData\RecordMaterias\ShurikenMaster.cs" />
     <Compile Include="GameData\RecordMaterias\SoldiersPride.cs" />
     <Compile Include="GameData\RecordMaterias\SoldierStrike.cs" />
@@ -518,6 +521,7 @@
     <Compile Include="GameData\SoulBreaks\FlamesOfRebirth.cs" />
     <Compile Include="GameData\SoulBreaks\FluidAura.cs" />
     <Compile Include="GameData\SoulBreaks\Froststrike.cs" />
+    <Compile Include="GameData\SoulBreaks\FulminatingDarkness.cs" />
     <Compile Include="GameData\SoulBreaks\Gauntlet.cs" />
     <Compile Include="GameData\SoulBreaks\GoddesssBell.cs" />
     <Compile Include="GameData\SoulBreaks\GrandCross.cs" />

--- a/client/FFRKInspector.csproj
+++ b/client/FFRKInspector.csproj
@@ -570,6 +570,7 @@
     <Compile Include="GameData\SoulBreaks\MeteorBarrage.cs" />
     <Compile Include="GameData\SoulBreaks\MiraclePrayer.cs" />
     <Compile Include="GameData\SoulBreaks\MirageDive.cs" />
+    <Compile Include="GameData\SoulBreaks\MistOverload.cs" />
     <Compile Include="GameData\SoulBreaks\Nekodamashi.cs" />
     <Compile Include="GameData\SoulBreaks\NibelheimNightmare.cs" />
     <Compile Include="GameData\SoulBreaks\Nightglow.cs" />

--- a/client/FFRKInspector.csproj
+++ b/client/FFRKInspector.csproj
@@ -84,6 +84,7 @@
     <Compile Include="DataCache\Worlds.cs" />
     <Compile Include="EquipmentStatsDataSet.cs">
       <DependentUpon>EquipmentStatsDataSet.xsd</DependentUpon>
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="EquipmentStatsDataSet.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -730,6 +731,12 @@
     <Compile Include="UI\DatabaseUI\FFRKViewDatabase.Designer.cs">
       <DependentUpon>FFRKViewDatabase.cs</DependentUpon>
     </Compile>
+    <Compile Include="UI\EquipmentSelectorModal.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UI\EquipmentSelectorModal.Designer.cs">
+      <DependentUpon>EquipmentSelectorModal.cs</DependentUpon>
+    </Compile>
     <Compile Include="UI\FFRKViewAbout.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -850,6 +857,9 @@
   <ItemGroup>
     <EmbeddedResource Include="UI\DatabaseUI\ItemStatsPanel.resx">
       <DependentUpon>ItemStatsPanel.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UI\EquipmentSelectorModal.resx">
+      <DependentUpon>EquipmentSelectorModal.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="UI\FFRKViewAbout.resx">
       <DependentUpon>FFRKViewAbout.cs</DependentUpon>

--- a/client/FFRKInspector.csproj
+++ b/client/FFRKInspector.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -846,7 +846,6 @@
     <Compile Include="UI\DatabaseUI\MissingItemsPanel.Designer.cs">
       <DependentUpon>MissingItemsPanel.cs</DependentUpon>
     </Compile>
-    <Compile Include="UI\SavedPartyData.cs" />
     <Compile Include="UI\SeriesDataGridViewCell.cs" />
     <Compile Include="Analyzer\AnalyzerSettings.cs" />
     <Compile Include="UI\TextInput.cs">

--- a/client/GameData/Abilities/ConfuseShell.cs
+++ b/client/GameData/Abilities/ConfuseShell.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFRKInspector.GameData.Abilities
+{
+    class ConfuseShell : FFRKInspector.GameData.Ability
+    {
+        public override uint AbilityId { get { return 30261041; } }
+        public override SchemaConstants.AbilityCategory Category { get { return SchemaConstants.AbilityCategory.Machinist; } }
+        public override SchemaConstants.Formulas Formula { get { return SchemaConstants.Formulas.Physical; } }
+        public override double Multiplier { get { return 1.9; } }
+        public override string Name { get { return "Confuse Shell"; } }
+        public override int Rarity { get { return 4; } }
+    }
+}

--- a/client/GameData/Abilities/EnvelopingEtude.cs
+++ b/client/GameData/Abilities/EnvelopingEtude.cs
@@ -11,6 +11,6 @@ namespace FFRKInspector.GameData.Abilities
         public override uint AbilityId { get { return 30241041; } }
         public override SchemaConstants.AbilityCategory Category { get { return SchemaConstants.AbilityCategory.Bard; } }
         public override string Name { get { return "Enveloping Etude"; } }
-        public override int Rarity { get { return 3; } }
+        public override int Rarity { get { return 4; } }
     }
 }

--- a/client/GameData/Abilities/ShieldBash.cs
+++ b/client/GameData/Abilities/ShieldBash.cs
@@ -12,7 +12,7 @@ namespace FFRKInspector.GameData.Abilities
         public override SchemaConstants.AbilityCategory Category { get { return SchemaConstants.AbilityCategory.Knight; } }
         public override SchemaConstants.Formulas Formula { get { return SchemaConstants.Formulas.Physical; } }
         public override double Multiplier { get { return 1.6; } }
-        public override string Name { get { return "Shield Bask"; } }
+        public override string Name { get { return "Shield Bash"; } }
         public override int Rarity { get { return 3; } }
     }
 }

--- a/client/GameData/Ability.cs
+++ b/client/GameData/Ability.cs
@@ -8,7 +8,7 @@ namespace FFRKInspector.GameData
 {
     abstract class Ability
     {       
-        public virtual uint AbilityId { get { return 0; } }
+        public virtual uint AbilityId { get { return 9999999; } }
         public virtual SchemaConstants.AbilityCategory Category { get { return SchemaConstants.AbilityCategory.None; } }
         public virtual SchemaConstants.ElementID Element { get { return SchemaConstants.ElementID.None; } }
         public virtual SchemaConstants.Formulas Formula { get { return SchemaConstants.Formulas.None; } }

--- a/client/GameData/Ability.cs
+++ b/client/GameData/Ability.cs
@@ -68,9 +68,9 @@ namespace FFRKInspector.GameData
         public virtual double MagicalDamage(double mag, double res)
         {
             double normal_damage = Math.Min(2000, Math.Pow(mag, 1.15)) * Math.Pow(mag, 0.5) / Math.Pow(res, 0.5);
-            if (MinimumDamage > 0)
+            if (MinimumDamage > 0 && MinimumDamage / Math.Pow(res, 0.05) > normal_damage)
             {
-                normal_damage = Math.Max(normal_damage, MinimumDamage / Math.Pow(res, 0.05) / Multiplier);
+                normal_damage = MinimumDamage / Math.Pow(res, 0.05) / Multiplier;
             }
             return normal_damage;
         }

--- a/client/GameData/Ability.cs
+++ b/client/GameData/Ability.cs
@@ -70,7 +70,7 @@ namespace FFRKInspector.GameData
             double normal_damage = Math.Min(2000, Math.Pow(mag, 1.15)) * Math.Pow(mag, 0.5) / Math.Pow(res, 0.5);
             if (MinimumDamage > 0)
             {
-                normal_damage = Math.Max(normal_damage, MinimumDamage / Math.Pow(res, 0.05));
+                normal_damage = Math.Max(normal_damage, MinimumDamage / Math.Pow(res, 0.05) / Multiplier);
             }
             return normal_damage;
         }

--- a/client/GameData/DataBuddyInformation.cs
+++ b/client/GameData/DataBuddyInformation.cs
@@ -31,7 +31,7 @@ namespace FFRKInspector.GameData
         [JsonProperty("level_max")]
         public byte LevelMax;
 
-        [JsonProperty("soul_strike_id")]
+        [JsonProperty("default_soul_strike_id")]
         public uint SoulStrike;
 
         [JsonProperty("job_name")]
@@ -118,7 +118,8 @@ namespace FFRKInspector.GameData
 
         public IEnumerable<SoulBreak> UsableSoulBreaks
         {
-            get { return SoulBreak.AllSoulBreaks().Where(soulBreak => SoulBreakExpMap.Keys.Any(sb => sb == soulBreak.SoulBreakId)); }
+            get { return SoulBreak.AllSoulBreaks().Where(soulBreak => SoulBreakExpMap.Keys.Any(sb => sb == soulBreak.SoulBreakId)
+                || soulBreak.SoulBreakId == SoulStrike); }
         }
 
         public override string ToString()

--- a/client/GameData/RecordMaterias/AceTurk.cs
+++ b/client/GameData/RecordMaterias/AceTurk.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Rod && (ability.Formula == SchemaConstants.Formulas.Physical || ability.Category == SchemaConstants.AbilityCategory.BlackMagic))
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Rod && (ability.Formula == SchemaConstants.Formulas.Physical || ability.Category == SchemaConstants.AbilityCategory.BlackMagic))
             {
                 return 1.2;
             }

--- a/client/GameData/RecordMaterias/AdventurersDagger.cs
+++ b/client/GameData/RecordMaterias/AdventurersDagger.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Dagger && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Dagger && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.2;
             }

--- a/client/GameData/RecordMaterias/ArcherInWhite.cs
+++ b/client/GameData/RecordMaterias/ArcherInWhite.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double MndModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Bow)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Bow)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/ArcherMage.cs
+++ b/client/GameData/RecordMaterias/ArcherMage.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Bow && ability.Category == SchemaConstants.AbilityCategory.BlackMagic)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Bow && ability.Category == SchemaConstants.AbilityCategory.BlackMagic)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/Ascendance.cs
+++ b/client/GameData/RecordMaterias/Ascendance.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Thrown && ability.Category == SchemaConstants.AbilityCategory.BlackMagic)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Thrown && ability.Category == SchemaConstants.AbilityCategory.BlackMagic)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/AxeMaster.cs
+++ b/client/GameData/RecordMaterias/AxeMaster.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Axe && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Axe && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/Bushido.cs
+++ b/client/GameData/RecordMaterias/Bushido.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Katana && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Katana && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/ConcertMusician.cs
+++ b/client/GameData/RecordMaterias/ConcertMusician.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Instrument && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Instrument && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/DesertBloom.cs
+++ b/client/GameData/RecordMaterias/DesertBloom.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFRKInspector.GameData.RecordMaterias
+{
+    class DesertBloom : RecordMateria
+    {
+        public override uint RecordMateriaId { get { return 111120061; } }
+        public override string Name { get { return "Desert Bloom"; } }
+
+        public override double MndModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory)
+        {
+            return 1.2;
+        }
+
+        public override double MagModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory)
+        {
+            return 0.9;
+        }
+
+        public override double AtkModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory)
+        {
+            return 0.9;
+        }
+    }
+}

--- a/client/GameData/RecordMaterias/FairiesBoon.cs
+++ b/client/GameData/RecordMaterias/FairiesBoon.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Gun && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Gun && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/FistOfDawn.cs
+++ b/client/GameData/RecordMaterias/FistOfDawn.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Fist && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Fist && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.2;
             }

--- a/client/GameData/RecordMaterias/FleshUndying.cs
+++ b/client/GameData/RecordMaterias/FleshUndying.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double MagModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Gun)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Gun)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/FraternalKnowledge.cs
+++ b/client/GameData/RecordMaterias/FraternalKnowledge.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Dagger && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Dagger && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/GiftOfTheShinobi.cs
+++ b/client/GameData/RecordMaterias/GiftOfTheShinobi.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Thrown && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Thrown && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/GranPulseWarrior.cs
+++ b/client/GameData/RecordMaterias/GranPulseWarrior.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Spear && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Spear && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/GranddaughtersLove.cs
+++ b/client/GameData/RecordMaterias/GranddaughtersLove.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double MndModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Rod)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Rod)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/HammerMaster.cs
+++ b/client/GameData/RecordMaterias/HammerMaster.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Hammer && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Hammer && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/HelmExpertise.cs
+++ b/client/GameData/RecordMaterias/HelmExpertise.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double DefModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory)
         {
-            if (armor.Category == SchemaConstants.EquipmentCategory.Helm)
+            if (armor != null && armor.Category == SchemaConstants.EquipmentCategory.Helm)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/HeroicStance.cs
+++ b/client/GameData/RecordMaterias/HeroicStance.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Katana && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Katana && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.2;
             }

--- a/client/GameData/RecordMaterias/HopeNotInVain.cs
+++ b/client/GameData/RecordMaterias/HopeNotInVain.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Thrown && ability.Category == SchemaConstants.AbilityCategory.BlackMagic)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Thrown && ability.Category == SchemaConstants.AbilityCategory.BlackMagic)
             {
                 return 1.2;
             }

--- a/client/GameData/RecordMaterias/Ironclad.cs
+++ b/client/GameData/RecordMaterias/Ironclad.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double DefModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory)
         {
-            if (armor.Category == SchemaConstants.EquipmentCategory.Armor)
+            if (armor != null && armor.Category == SchemaConstants.EquipmentCategory.Armor)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/KatanaMaster.cs
+++ b/client/GameData/RecordMaterias/KatanaMaster.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Katana && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Katana && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/LegendaryShot.cs
+++ b/client/GameData/RecordMaterias/LegendaryShot.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Ball && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Ball && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/LovingSoul.cs
+++ b/client/GameData/RecordMaterias/LovingSoul.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double MndModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Staff)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Staff)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/MasterArcher.cs
+++ b/client/GameData/RecordMaterias/MasterArcher.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Bow && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Bow && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/MasterSniper.cs
+++ b/client/GameData/RecordMaterias/MasterSniper.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Gun && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Gun && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.2;
             }

--- a/client/GameData/RecordMaterias/PiratesCode.cs
+++ b/client/GameData/RecordMaterias/PiratesCode.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Dagger && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Dagger && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/PrideOfTheRedWings.cs
+++ b/client/GameData/RecordMaterias/PrideOfTheRedWings.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Sword && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Sword && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.2;
             }

--- a/client/GameData/RecordMaterias/PugilistsLore.cs
+++ b/client/GameData/RecordMaterias/PugilistsLore.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Fist && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Fist && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/RebelSharpshooter.cs
+++ b/client/GameData/RecordMaterias/RebelSharpshooter.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Bow && 
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Bow && 
                 (ability.Category == SchemaConstants.AbilityCategory.BlackMagic || ability.Formula == SchemaConstants.Formulas.Physical))
             {
                 return 1.1;

--- a/client/GameData/RecordMaterias/RodMaster.cs
+++ b/client/GameData/RecordMaterias/RodMaster.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Rod && ability.Category == SchemaConstants.AbilityCategory.BlackMagic)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Rod && ability.Category == SchemaConstants.AbilityCategory.BlackMagic)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/RonsoPride.cs
+++ b/client/GameData/RecordMaterias/RonsoPride.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Spear && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Spear && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/ShieldOfDalmasca.cs
+++ b/client/GameData/RecordMaterias/ShieldOfDalmasca.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFRKInspector.GameData.RecordMaterias
+{
+    class ShieldOfDalmasca : RecordMateria
+    {
+        public override uint RecordMateriaId { get { return 111120040; } }
+        public override string Name { get { return "Shield of Dalmasca"; } }
+
+        public override double AtkModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory)
+        {
+            if (armor != null && armor.Category == SchemaConstants.EquipmentCategory.Shield)
+            {
+                return 1.1;
+            }
+            return 1.0;
+        }
+    }
+}

--- a/client/GameData/RecordMaterias/ShurikenMaster.cs
+++ b/client/GameData/RecordMaterias/ShurikenMaster.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Thrown && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Thrown && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/SoldierStrike.cs
+++ b/client/GameData/RecordMaterias/SoldierStrike.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Sword && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Sword && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/SoldiersPride.cs
+++ b/client/GameData/RecordMaterias/SoldiersPride.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Sword && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Sword && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/SummonersPrayer.cs
+++ b/client/GameData/RecordMaterias/SummonersPrayer.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double MndModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Rod)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Rod)
             {
                 return 1.2;
             }

--- a/client/GameData/RecordMaterias/UnerringShot.cs
+++ b/client/GameData/RecordMaterias/UnerringShot.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Gun && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Gun && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.2;
             }

--- a/client/GameData/RecordMaterias/VieraVirtuoso.cs
+++ b/client/GameData/RecordMaterias/VieraVirtuoso.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Bow && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Bow && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.2;
             }

--- a/client/GameData/RecordMaterias/WarriorsBurden.cs
+++ b/client/GameData/RecordMaterias/WarriorsBurden.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double DefModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory)
         {
-            if (armor.Category == SchemaConstants.EquipmentCategory.Armor)
+            if (armor != null && armor.Category == SchemaConstants.EquipmentCategory.Armor)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/WayOfTheFist.cs
+++ b/client/GameData/RecordMaterias/WayOfTheFist.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Fist && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Fist && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/WhiteShepherd.cs
+++ b/client/GameData/RecordMaterias/WhiteShepherd.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double MndModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Staff)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Staff)
             {
                 return 1.1;
             }

--- a/client/GameData/RecordMaterias/ZanganWay.cs
+++ b/client/GameData/RecordMaterias/ZanganWay.cs
@@ -13,7 +13,7 @@ namespace FFRKInspector.GameData.RecordMaterias
 
         public override double AbilityModifier(Party.DataEquipmentInformation weapon, Party.DataEquipmentInformation armor, Party.DataEquipmentInformation accessory, Ability ability)
         {
-            if (weapon.Category == SchemaConstants.EquipmentCategory.Fist && ability.Formula == SchemaConstants.Formulas.Physical)
+            if (weapon != null && weapon.Category == SchemaConstants.EquipmentCategory.Fist && ability.Formula == SchemaConstants.Formulas.Physical)
             {
                 return 1.2;
             }

--- a/client/GameData/SoulBreaks/FulminatingDarkness.cs
+++ b/client/GameData/SoulBreaks/FulminatingDarkness.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFRKInspector.GameData.SoulBreaks
+{
+    class FulminatingDarkness : FFRKInspector.GameData.SoulBreak
+    {
+        public override uint SoulBreakId { get { return 22180003; } }
+        public override SchemaConstants.BuddyID BuddyId { get { return SchemaConstants.BuddyID.BASCH; } }
+        public override SchemaConstants.ElementID Element { get { return SchemaConstants.ElementID.Dark; } }
+        public override SchemaConstants.Formulas Formula { get { return SchemaConstants.Formulas.Physical; } }
+        public override double Multiplier { get { return 1.35; } }
+        public override string Name { get { return "Fulminating Darkness"; } }
+        public override int NumberOfHits { get { return 3; } }
+    }
+}

--- a/client/GameData/SoulBreaks/MistOverload.cs
+++ b/client/GameData/SoulBreaks/MistOverload.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFRKInspector.GameData.SoulBreaks
+{
+    class MistOverload : FFRKInspector.GameData.SoulBreak
+    {
+        public override uint SoulBreakId { get { return 20390004; } }
+        public override SchemaConstants.BuddyID BuddyId { get { return SchemaConstants.BuddyID.FRAN; } }
+        public override SchemaConstants.Formulas Formula { get { return SchemaConstants.Formulas.Physical; } }
+        public override double Multiplier { get { return 1.13; } }
+        public override string Name { get { return "Mist Overload"; } }
+        public override int NumberOfHits { get { return 7; } }
+    }
+}

--- a/client/UI/EquipmentSelectorModal.Designer.cs
+++ b/client/UI/EquipmentSelectorModal.Designer.cs
@@ -1,0 +1,311 @@
+﻿namespace FFRKInspector.UI
+{
+    partial class EquipmentSelectorModal
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.buttonClose = new System.Windows.Forms.Button();
+            this.dataGridViewEquipment = new System.Windows.Forms.DataGridView();
+            this.ItemColumn = new System.Windows.Forms.DataGridViewButtonColumn();
+            this.comboBoxRealmSynergy = new System.Windows.Forms.ComboBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dataGridViewTextBoxColumn7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dataGridViewTextBoxColumn8 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.AtkColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.MagColunm = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.MndColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.DefColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ResColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.AccColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.EvaColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.SpdColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewEquipment)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // buttonClose
+            // 
+            this.buttonClose.Location = new System.Drawing.Point(682, 476);
+            this.buttonClose.Name = "buttonClose";
+            this.buttonClose.Size = new System.Drawing.Size(75, 23);
+            this.buttonClose.TabIndex = 1;
+            this.buttonClose.Text = "Close";
+            this.buttonClose.UseVisualStyleBackColor = true;
+            this.buttonClose.Click += new System.EventHandler(this.buttonClose_Click);
+            // 
+            // dataGridViewEquipment
+            // 
+            this.dataGridViewEquipment.AllowUserToAddRows = false;
+            this.dataGridViewEquipment.AllowUserToDeleteRows = false;
+            this.dataGridViewEquipment.AllowUserToOrderColumns = true;
+            this.dataGridViewEquipment.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridViewEquipment.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.ItemColumn,
+            this.AtkColumn,
+            this.MagColunm,
+            this.MndColumn,
+            this.DefColumn,
+            this.ResColumn,
+            this.AccColumn,
+            this.EvaColumn,
+            this.SpdColumn});
+            this.dataGridViewEquipment.Location = new System.Drawing.Point(12, 39);
+            this.dataGridViewEquipment.Name = "dataGridViewEquipment";
+            this.dataGridViewEquipment.ReadOnly = true;
+            this.dataGridViewEquipment.Size = new System.Drawing.Size(745, 431);
+            this.dataGridViewEquipment.TabIndex = 71;
+            this.dataGridViewEquipment.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewEquipment_CellContentClick);
+            // 
+            // ItemColumn
+            // 
+            this.ItemColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.ItemColumn.HeaderText = "Item";
+            this.ItemColumn.Name = "ItemColumn";
+            this.ItemColumn.ReadOnly = true;
+            this.ItemColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.ItemColumn.Width = 52;
+            // 
+            // comboBoxRealmSynergy
+            // 
+            this.comboBoxRealmSynergy.FormattingEnabled = true;
+            this.comboBoxRealmSynergy.Location = new System.Drawing.Point(636, 12);
+            this.comboBoxRealmSynergy.Name = "comboBoxRealmSynergy";
+            this.comboBoxRealmSynergy.Size = new System.Drawing.Size(121, 21);
+            this.comboBoxRealmSynergy.TabIndex = 72;
+            this.comboBoxRealmSynergy.SelectedIndexChanged += new System.EventHandler(this.comboBoxRealmSynergy_SelectedIndexChanged);
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(552, 15);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(78, 13);
+            this.label1.TabIndex = 73;
+            this.label1.Text = "Realm Synergy";
+            // 
+            // dataGridViewTextBoxColumn1
+            // 
+            this.dataGridViewTextBoxColumn1.HeaderText = "Atk";
+            this.dataGridViewTextBoxColumn1.MaxInputLength = 4;
+            this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
+            this.dataGridViewTextBoxColumn1.ReadOnly = true;
+            this.dataGridViewTextBoxColumn1.Width = 65;
+            // 
+            // dataGridViewTextBoxColumn2
+            // 
+            this.dataGridViewTextBoxColumn2.HeaderText = "Mag";
+            this.dataGridViewTextBoxColumn2.MaxInputLength = 4;
+            this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
+            this.dataGridViewTextBoxColumn2.ReadOnly = true;
+            this.dataGridViewTextBoxColumn2.Width = 66;
+            // 
+            // dataGridViewTextBoxColumn3
+            // 
+            this.dataGridViewTextBoxColumn3.HeaderText = "Mnd";
+            this.dataGridViewTextBoxColumn3.MaxInputLength = 4;
+            this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
+            this.dataGridViewTextBoxColumn3.ReadOnly = true;
+            this.dataGridViewTextBoxColumn3.Width = 66;
+            // 
+            // dataGridViewTextBoxColumn4
+            // 
+            this.dataGridViewTextBoxColumn4.HeaderText = "Def";
+            this.dataGridViewTextBoxColumn4.MaxInputLength = 4;
+            this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
+            this.dataGridViewTextBoxColumn4.ReadOnly = true;
+            this.dataGridViewTextBoxColumn4.Width = 66;
+            // 
+            // dataGridViewTextBoxColumn5
+            // 
+            this.dataGridViewTextBoxColumn5.HeaderText = "Res";
+            this.dataGridViewTextBoxColumn5.MaxInputLength = 4;
+            this.dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
+            this.dataGridViewTextBoxColumn5.ReadOnly = true;
+            this.dataGridViewTextBoxColumn5.Width = 66;
+            // 
+            // dataGridViewTextBoxColumn6
+            // 
+            this.dataGridViewTextBoxColumn6.HeaderText = "Acc";
+            this.dataGridViewTextBoxColumn6.MaxInputLength = 4;
+            this.dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
+            this.dataGridViewTextBoxColumn6.ReadOnly = true;
+            this.dataGridViewTextBoxColumn6.Width = 66;
+            // 
+            // dataGridViewTextBoxColumn7
+            // 
+            this.dataGridViewTextBoxColumn7.HeaderText = "Eva";
+            this.dataGridViewTextBoxColumn7.MaxInputLength = 4;
+            this.dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
+            this.dataGridViewTextBoxColumn7.ReadOnly = true;
+            this.dataGridViewTextBoxColumn7.Width = 66;
+            // 
+            // dataGridViewTextBoxColumn8
+            // 
+            this.dataGridViewTextBoxColumn8.HeaderText = "Spd";
+            this.dataGridViewTextBoxColumn8.MaxInputLength = 4;
+            this.dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
+            this.dataGridViewTextBoxColumn8.ReadOnly = true;
+            this.dataGridViewTextBoxColumn8.Width = 66;
+            // 
+            // AtkColumn
+            // 
+            this.AtkColumn.HeaderText = "Atk";
+            this.AtkColumn.MaxInputLength = 4;
+            this.AtkColumn.Name = "AtkColumn";
+            this.AtkColumn.ReadOnly = true;
+            this.AtkColumn.Width = 65;
+            // 
+            // MagColunm
+            // 
+            this.MagColunm.HeaderText = "Mag";
+            this.MagColunm.MaxInputLength = 4;
+            this.MagColunm.Name = "MagColunm";
+            this.MagColunm.ReadOnly = true;
+            this.MagColunm.Width = 66;
+            // 
+            // MndColumn
+            // 
+            this.MndColumn.HeaderText = "Mnd";
+            this.MndColumn.MaxInputLength = 4;
+            this.MndColumn.Name = "MndColumn";
+            this.MndColumn.ReadOnly = true;
+            this.MndColumn.Width = 66;
+            // 
+            // DefColumn
+            // 
+            this.DefColumn.HeaderText = "Def";
+            this.DefColumn.MaxInputLength = 4;
+            this.DefColumn.Name = "DefColumn";
+            this.DefColumn.ReadOnly = true;
+            this.DefColumn.Width = 66;
+            // 
+            // ResColumn
+            // 
+            this.ResColumn.HeaderText = "Res";
+            this.ResColumn.MaxInputLength = 4;
+            this.ResColumn.Name = "ResColumn";
+            this.ResColumn.ReadOnly = true;
+            this.ResColumn.Width = 66;
+            // 
+            // AccColumn
+            // 
+            this.AccColumn.HeaderText = "Acc";
+            this.AccColumn.MaxInputLength = 4;
+            this.AccColumn.Name = "AccColumn";
+            this.AccColumn.ReadOnly = true;
+            this.AccColumn.Width = 66;
+            // 
+            // EvaColumn
+            // 
+            this.EvaColumn.HeaderText = "Eva";
+            this.EvaColumn.MaxInputLength = 4;
+            this.EvaColumn.Name = "EvaColumn";
+            this.EvaColumn.ReadOnly = true;
+            this.EvaColumn.Width = 66;
+            // 
+            // SpdColumn
+            // 
+            this.SpdColumn.HeaderText = "Spd";
+            this.SpdColumn.MaxInputLength = 4;
+            this.SpdColumn.Name = "SpdColumn";
+            this.SpdColumn.ReadOnly = true;
+            this.SpdColumn.Width = 66;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(12, 9);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(279, 13);
+            this.label2.TabIndex = 74;
+            this.label2.Text = "Red rows are items already equipped on other characters.";
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(12, 22);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(207, 13);
+            this.label3.TabIndex = 75;
+            this.label3.Text = "Blue rows are items with Synergy bonuses.";
+            // 
+            // EquipmentSelectorModal
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(769, 511);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.comboBoxRealmSynergy);
+            this.Controls.Add(this.dataGridViewEquipment);
+            this.Controls.Add(this.buttonClose);
+            this.Name = "EquipmentSelectorModal";
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Select Equipment";
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewEquipment)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button buttonClose;
+        private System.Windows.Forms.DataGridView dataGridViewEquipment;
+        private System.Windows.Forms.DataGridViewButtonColumn ItemColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn AtkColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn MagColunm;
+        private System.Windows.Forms.DataGridViewTextBoxColumn MndColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn DefColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ResColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn AccColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn EvaColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn SpdColumn;
+        private System.Windows.Forms.ComboBox comboBoxRealmSynergy;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn1;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn2;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn3;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn4;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn5;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn6;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn7;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn8;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label3;
+    }
+}

--- a/client/UI/EquipmentSelectorModal.Designer.cs
+++ b/client/UI/EquipmentSelectorModal.Designer.cs
@@ -31,6 +31,14 @@
             this.buttonClose = new System.Windows.Forms.Button();
             this.dataGridViewEquipment = new System.Windows.Forms.DataGridView();
             this.ItemColumn = new System.Windows.Forms.DataGridViewButtonColumn();
+            this.AtkColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.MagColunm = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.MndColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.DefColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ResColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.AccColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.EvaColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.SpdColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.comboBoxRealmSynergy = new System.Windows.Forms.ComboBox();
             this.label1 = new System.Windows.Forms.Label();
             this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -41,14 +49,6 @@
             this.dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dataGridViewTextBoxColumn7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dataGridViewTextBoxColumn8 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.AtkColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.MagColunm = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.MndColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.DefColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ResColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.AccColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.EvaColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.SpdColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.label2 = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewEquipment)).BeginInit();
@@ -56,10 +56,11 @@
             // 
             // buttonClose
             // 
+            this.buttonClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonClose.Location = new System.Drawing.Point(682, 476);
             this.buttonClose.Name = "buttonClose";
             this.buttonClose.Size = new System.Drawing.Size(75, 23);
-            this.buttonClose.TabIndex = 1;
+            this.buttonClose.TabIndex = 2;
             this.buttonClose.Text = "Close";
             this.buttonClose.UseVisualStyleBackColor = true;
             this.buttonClose.Click += new System.EventHandler(this.buttonClose_Click);
@@ -69,6 +70,9 @@
             this.dataGridViewEquipment.AllowUserToAddRows = false;
             this.dataGridViewEquipment.AllowUserToDeleteRows = false;
             this.dataGridViewEquipment.AllowUserToOrderColumns = true;
+            this.dataGridViewEquipment.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.dataGridViewEquipment.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridViewEquipment.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.ItemColumn,
@@ -83,8 +87,9 @@
             this.dataGridViewEquipment.Location = new System.Drawing.Point(12, 39);
             this.dataGridViewEquipment.Name = "dataGridViewEquipment";
             this.dataGridViewEquipment.ReadOnly = true;
+            this.dataGridViewEquipment.RowHeadersVisible = false;
             this.dataGridViewEquipment.Size = new System.Drawing.Size(745, 431);
-            this.dataGridViewEquipment.TabIndex = 71;
+            this.dataGridViewEquipment.TabIndex = 1;
             this.dataGridViewEquipment.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewEquipment_CellContentClick);
             // 
             // ItemColumn
@@ -96,17 +101,83 @@
             this.ItemColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
             this.ItemColumn.Width = 52;
             // 
+            // AtkColumn
+            // 
+            this.AtkColumn.HeaderText = "Atk";
+            this.AtkColumn.MaxInputLength = 4;
+            this.AtkColumn.Name = "AtkColumn";
+            this.AtkColumn.ReadOnly = true;
+            this.AtkColumn.Width = 65;
+            // 
+            // MagColunm
+            // 
+            this.MagColunm.HeaderText = "Mag";
+            this.MagColunm.MaxInputLength = 4;
+            this.MagColunm.Name = "MagColunm";
+            this.MagColunm.ReadOnly = true;
+            this.MagColunm.Width = 66;
+            // 
+            // MndColumn
+            // 
+            this.MndColumn.HeaderText = "Mnd";
+            this.MndColumn.MaxInputLength = 4;
+            this.MndColumn.Name = "MndColumn";
+            this.MndColumn.ReadOnly = true;
+            this.MndColumn.Width = 66;
+            // 
+            // DefColumn
+            // 
+            this.DefColumn.HeaderText = "Def";
+            this.DefColumn.MaxInputLength = 4;
+            this.DefColumn.Name = "DefColumn";
+            this.DefColumn.ReadOnly = true;
+            this.DefColumn.Width = 66;
+            // 
+            // ResColumn
+            // 
+            this.ResColumn.HeaderText = "Res";
+            this.ResColumn.MaxInputLength = 4;
+            this.ResColumn.Name = "ResColumn";
+            this.ResColumn.ReadOnly = true;
+            this.ResColumn.Width = 66;
+            // 
+            // AccColumn
+            // 
+            this.AccColumn.HeaderText = "Acc";
+            this.AccColumn.MaxInputLength = 4;
+            this.AccColumn.Name = "AccColumn";
+            this.AccColumn.ReadOnly = true;
+            this.AccColumn.Width = 66;
+            // 
+            // EvaColumn
+            // 
+            this.EvaColumn.HeaderText = "Eva";
+            this.EvaColumn.MaxInputLength = 4;
+            this.EvaColumn.Name = "EvaColumn";
+            this.EvaColumn.ReadOnly = true;
+            this.EvaColumn.Width = 66;
+            // 
+            // SpdColumn
+            // 
+            this.SpdColumn.HeaderText = "Spd";
+            this.SpdColumn.MaxInputLength = 4;
+            this.SpdColumn.Name = "SpdColumn";
+            this.SpdColumn.ReadOnly = true;
+            this.SpdColumn.Width = 66;
+            // 
             // comboBoxRealmSynergy
             // 
+            this.comboBoxRealmSynergy.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxRealmSynergy.FormattingEnabled = true;
             this.comboBoxRealmSynergy.Location = new System.Drawing.Point(636, 12);
             this.comboBoxRealmSynergy.Name = "comboBoxRealmSynergy";
             this.comboBoxRealmSynergy.Size = new System.Drawing.Size(121, 21);
-            this.comboBoxRealmSynergy.TabIndex = 72;
+            this.comboBoxRealmSynergy.TabIndex = 0;
             this.comboBoxRealmSynergy.SelectedIndexChanged += new System.EventHandler(this.comboBoxRealmSynergy_SelectedIndexChanged);
             // 
             // label1
             // 
+            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(552, 15);
             this.label1.Name = "label1";
@@ -177,70 +248,6 @@
             this.dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
             this.dataGridViewTextBoxColumn8.ReadOnly = true;
             this.dataGridViewTextBoxColumn8.Width = 66;
-            // 
-            // AtkColumn
-            // 
-            this.AtkColumn.HeaderText = "Atk";
-            this.AtkColumn.MaxInputLength = 4;
-            this.AtkColumn.Name = "AtkColumn";
-            this.AtkColumn.ReadOnly = true;
-            this.AtkColumn.Width = 65;
-            // 
-            // MagColunm
-            // 
-            this.MagColunm.HeaderText = "Mag";
-            this.MagColunm.MaxInputLength = 4;
-            this.MagColunm.Name = "MagColunm";
-            this.MagColunm.ReadOnly = true;
-            this.MagColunm.Width = 66;
-            // 
-            // MndColumn
-            // 
-            this.MndColumn.HeaderText = "Mnd";
-            this.MndColumn.MaxInputLength = 4;
-            this.MndColumn.Name = "MndColumn";
-            this.MndColumn.ReadOnly = true;
-            this.MndColumn.Width = 66;
-            // 
-            // DefColumn
-            // 
-            this.DefColumn.HeaderText = "Def";
-            this.DefColumn.MaxInputLength = 4;
-            this.DefColumn.Name = "DefColumn";
-            this.DefColumn.ReadOnly = true;
-            this.DefColumn.Width = 66;
-            // 
-            // ResColumn
-            // 
-            this.ResColumn.HeaderText = "Res";
-            this.ResColumn.MaxInputLength = 4;
-            this.ResColumn.Name = "ResColumn";
-            this.ResColumn.ReadOnly = true;
-            this.ResColumn.Width = 66;
-            // 
-            // AccColumn
-            // 
-            this.AccColumn.HeaderText = "Acc";
-            this.AccColumn.MaxInputLength = 4;
-            this.AccColumn.Name = "AccColumn";
-            this.AccColumn.ReadOnly = true;
-            this.AccColumn.Width = 66;
-            // 
-            // EvaColumn
-            // 
-            this.EvaColumn.HeaderText = "Eva";
-            this.EvaColumn.MaxInputLength = 4;
-            this.EvaColumn.Name = "EvaColumn";
-            this.EvaColumn.ReadOnly = true;
-            this.EvaColumn.Width = 66;
-            // 
-            // SpdColumn
-            // 
-            this.SpdColumn.HeaderText = "Spd";
-            this.SpdColumn.MaxInputLength = 4;
-            this.SpdColumn.Name = "SpdColumn";
-            this.SpdColumn.ReadOnly = true;
-            this.SpdColumn.Width = 66;
             // 
             // label2
             // 

--- a/client/UI/EquipmentSelectorModal.cs
+++ b/client/UI/EquipmentSelectorModal.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace FFRKInspector.UI
+{
+    public partial class EquipmentSelectorModal : Form
+    {
+        private GameData.DataBuddyInformation mCharacter;
+        private ComboBox mEquipmentList;
+        private List<uint> mEquippedItems;
+        public uint SelectedInstanceId { get; set; }
+        
+        public EquipmentSelectorModal()
+        {
+            InitializeComponent();
+        }
+
+
+        public void UpdateEquipmentGrid(object character, ComboBox equipmentList, List<uint> equippedItems, FFRKViewPartyPlanner.Synergy realmSynergy)
+        {
+            mCharacter = (GameData.DataBuddyInformation)character;
+            mEquipmentList = equipmentList;
+            mEquippedItems = equippedItems;
+            bool characterHasSynergy = mCharacter != null && (mCharacter.SeriesId == realmSynergy.SeriesId ||
+                mCharacter.EligibleForNightmareShift(realmSynergy.NightmareCategory));
+            for (int i = 0; i < comboBoxRealmSynergy.Items.Count; i++)
+            {
+                if (((FFRKViewPartyPlanner.Synergy)comboBoxRealmSynergy.Items[i]).SeriesId == realmSynergy.SeriesId)
+                {
+                    comboBoxRealmSynergy.SelectedIndex = i;
+                    break;
+                }
+            }
+            dataGridViewEquipment.Rows.Clear();
+            foreach (GameData.Party.DataEquipmentInformation item in equipmentList.Items)
+            {
+                bool itemHasSynergy = item.SeriesId == realmSynergy.SeriesId ||
+                    mCharacter.EligibleForNightmareShift(realmSynergy.NightmareCategory);
+                bool itemEquippedElsewhere = equippedItems.Any(equippedItemId => equippedItemId == item.InstanceId);
+                DataGridViewRow row = new DataGridViewRow();
+                row.Tag = item;
+
+                DataGridViewCell cell = new DataGridViewButtonCell();
+                cell.Value = item.Name;
+                cell.Tag = item.InstanceId;
+                row.Cells.Add(cell);
+
+                cell = new DataGridViewTextBoxCell();
+                cell.Value = item.StatWithSynergy("Atk", itemHasSynergy);
+                row.Cells.Add(cell);
+
+                cell = new DataGridViewTextBoxCell();
+                cell.Value = item.StatWithSynergy("Mag", itemHasSynergy);
+                row.Cells.Add(cell);
+
+                cell = new DataGridViewTextBoxCell();
+                cell.Value = item.StatWithSynergy("Mnd", itemHasSynergy);
+                row.Cells.Add(cell);
+
+                cell = new DataGridViewTextBoxCell();
+                cell.Value = item.StatWithSynergy("Def", itemHasSynergy);
+                row.Cells.Add(cell);
+
+                cell = new DataGridViewTextBoxCell();
+                cell.Value = item.StatWithSynergy("Res", itemHasSynergy);
+                row.Cells.Add(cell);
+
+                cell = new DataGridViewTextBoxCell();
+                cell.Value = item.StatWithSynergy("Acc", itemHasSynergy);
+                row.Cells.Add(cell);
+
+                cell = new DataGridViewTextBoxCell();
+                cell.Value = item.StatWithSynergy("Eva", itemHasSynergy);
+                row.Cells.Add(cell);
+
+                cell = new DataGridViewTextBoxCell();
+                cell.Value = item.StatWithSynergy("Spd", itemHasSynergy);
+                row.Cells.Add(cell);
+
+                if (itemEquippedElsewhere)
+                {
+                    row.DefaultCellStyle.BackColor = System.Drawing.Color.Red;
+                }
+                else if (itemHasSynergy)
+                {
+                    row.DefaultCellStyle.BackColor = System.Drawing.Color.Aqua;
+                }
+                else
+                {
+                    row.DefaultCellStyle.BackColor = System.Drawing.Color.Empty;
+                }
+
+                dataGridViewEquipment.Rows.Add(row);
+            }
+            if (dataGridViewEquipment.SortedColumn != null)
+            {
+                ListSortDirection sortDirection = dataGridViewEquipment.SortOrder == SortOrder.Descending ?
+                    ListSortDirection.Descending : ListSortDirection.Ascending;
+                dataGridViewEquipment.Sort(dataGridViewEquipment.SortedColumn, sortDirection);
+            }
+        }
+
+        private FFRKViewPartyPlanner.Synergy RealmSynergy
+        {
+            get
+            {
+                if (comboBoxRealmSynergy.SelectedItem != null)
+                {
+                    return (FFRKViewPartyPlanner.Synergy)comboBoxRealmSynergy.SelectedItem;
+                }
+                return (FFRKViewPartyPlanner.Synergy)comboBoxRealmSynergy.Items[0];
+            }
+        }
+        
+        public void UpdateRealmSynergies(ComboBox.ObjectCollection synergies)
+        {
+            comboBoxRealmSynergy.Items.Clear();
+            foreach (FFRKViewPartyPlanner.Synergy synergy in synergies)
+            {
+                comboBoxRealmSynergy.Items.Add(synergy);
+            }
+        }
+
+        private void buttonClose_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.Close();
+        }
+
+        private void comboBoxRealmSynergy_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            UpdateEquipmentGrid(mCharacter, mEquipmentList, mEquippedItems, RealmSynergy);
+        }
+
+        private void dataGridViewEquipment_CellContentClick(object sender, DataGridViewCellEventArgs e)
+        {
+            var senderGrid = (DataGridView)sender;
+
+            if (senderGrid.Columns[e.ColumnIndex] is DataGridViewButtonColumn &&
+                e.RowIndex >= 0)
+            {
+                var button = (DataGridViewButtonCell)senderGrid.Rows[e.RowIndex].Cells[0];
+                SelectedInstanceId = (uint)button.Tag;
+                this.DialogResult = System.Windows.Forms.DialogResult.OK;
+                this.Close();
+            }
+        }
+    }
+}

--- a/client/UI/EquipmentSelectorModal.resx
+++ b/client/UI/EquipmentSelectorModal.resx
@@ -1,0 +1,147 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="ItemColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="AtkColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="MagColunm.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="MndColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="DefColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="ResColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="AccColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="EvaColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="SpdColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+</root>

--- a/client/UI/EquipmentSelectorModal.resx
+++ b/client/UI/EquipmentSelectorModal.resx
@@ -144,4 +144,31 @@
   <metadata name="SpdColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="ItemColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="AtkColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="MagColunm.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="MndColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="DefColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="ResColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="AccColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="EvaColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="SpdColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
 </root>

--- a/client/UI/FFRKViewPartyPlanner.Designer.cs
+++ b/client/UI/FFRKViewPartyPlanner.Designer.cs
@@ -395,6 +395,7 @@
             this.comboBoxWeapon5.TabIndex = 36;
             this.comboBoxWeapon5.Text = "Weapon";
             this.comboBoxWeapon5.SelectedIndexChanged += new System.EventHandler(this.comboBoxWeapon_SelectedIndexChanged);
+            this.comboBoxWeapon5.Click += new System.EventHandler(this.comboBoxWeapon_Click);
             // 
             // comboBoxWeapon4
             // 
@@ -406,6 +407,7 @@
             this.comboBoxWeapon4.TabIndex = 28;
             this.comboBoxWeapon4.Text = "Weapon";
             this.comboBoxWeapon4.SelectedIndexChanged += new System.EventHandler(this.comboBoxWeapon_SelectedIndexChanged);
+            this.comboBoxWeapon4.Click += new System.EventHandler(this.comboBoxWeapon_Click);
             // 
             // comboBoxWeapon3
             // 
@@ -417,6 +419,7 @@
             this.comboBoxWeapon3.TabIndex = 20;
             this.comboBoxWeapon3.Text = "Weapon";
             this.comboBoxWeapon3.SelectedIndexChanged += new System.EventHandler(this.comboBoxWeapon_SelectedIndexChanged);
+            this.comboBoxWeapon3.Click += new System.EventHandler(this.comboBoxWeapon_Click);
             // 
             // comboBoxWeapon2
             // 
@@ -428,6 +431,7 @@
             this.comboBoxWeapon2.TabIndex = 12;
             this.comboBoxWeapon2.Text = "Weapon";
             this.comboBoxWeapon2.SelectedIndexChanged += new System.EventHandler(this.comboBoxWeapon_SelectedIndexChanged);
+            this.comboBoxWeapon2.Click += new System.EventHandler(this.comboBoxWeapon_Click);
             // 
             // comboBoxWeapon1
             // 
@@ -439,6 +443,7 @@
             this.comboBoxWeapon1.TabIndex = 4;
             this.comboBoxWeapon1.Text = "Weapon";
             this.comboBoxWeapon1.SelectedIndexChanged += new System.EventHandler(this.comboBoxWeapon_SelectedIndexChanged);
+            this.comboBoxWeapon1.Click += new System.EventHandler(this.comboBoxWeapon_Click);
             // 
             // comboBoxArmor5
             // 
@@ -450,6 +455,7 @@
             this.comboBoxArmor5.TabIndex = 37;
             this.comboBoxArmor5.Text = "Armor";
             this.comboBoxArmor5.SelectedIndexChanged += new System.EventHandler(this.comboBoxArmor_SelectedIndexChanged);
+            this.comboBoxArmor5.Click += new System.EventHandler(this.comboBoxArmor_Click);
             // 
             // comboBoxArmor4
             // 
@@ -461,6 +467,7 @@
             this.comboBoxArmor4.TabIndex = 29;
             this.comboBoxArmor4.Text = "Armor";
             this.comboBoxArmor4.SelectedIndexChanged += new System.EventHandler(this.comboBoxArmor_SelectedIndexChanged);
+            this.comboBoxArmor4.Click += new System.EventHandler(this.comboBoxArmor_Click);
             // 
             // comboBoxArmor3
             // 
@@ -472,6 +479,7 @@
             this.comboBoxArmor3.TabIndex = 21;
             this.comboBoxArmor3.Text = "Armor";
             this.comboBoxArmor3.SelectedIndexChanged += new System.EventHandler(this.comboBoxArmor_SelectedIndexChanged);
+            this.comboBoxArmor3.Click += new System.EventHandler(this.comboBoxArmor_Click);
             // 
             // comboBoxArmor2
             // 
@@ -483,6 +491,7 @@
             this.comboBoxArmor2.TabIndex = 13;
             this.comboBoxArmor2.Text = "Armor";
             this.comboBoxArmor2.SelectedIndexChanged += new System.EventHandler(this.comboBoxArmor_SelectedIndexChanged);
+            this.comboBoxArmor2.Click += new System.EventHandler(this.comboBoxArmor_Click);
             // 
             // comboBoxArmor1
             // 
@@ -494,6 +503,7 @@
             this.comboBoxArmor1.TabIndex = 5;
             this.comboBoxArmor1.Text = "Armor";
             this.comboBoxArmor1.SelectedIndexChanged += new System.EventHandler(this.comboBoxArmor_SelectedIndexChanged);
+            this.comboBoxArmor1.Click += new System.EventHandler(this.comboBoxArmor_Click);
             // 
             // comboBoxAccessory5
             // 
@@ -505,6 +515,7 @@
             this.comboBoxAccessory5.TabIndex = 38;
             this.comboBoxAccessory5.Text = "Accessory";
             this.comboBoxAccessory5.SelectedIndexChanged += new System.EventHandler(this.comboBoxAccessory_SelectedIndexChanged);
+            this.comboBoxAccessory5.Click += new System.EventHandler(this.comboBoxAccessory_Click);
             // 
             // comboBoxAccessory4
             // 
@@ -516,6 +527,7 @@
             this.comboBoxAccessory4.TabIndex = 30;
             this.comboBoxAccessory4.Text = "Accessory";
             this.comboBoxAccessory4.SelectedIndexChanged += new System.EventHandler(this.comboBoxAccessory_SelectedIndexChanged);
+            this.comboBoxAccessory4.Click += new System.EventHandler(this.comboBoxAccessory_Click);
             // 
             // comboBoxAccessory3
             // 
@@ -527,6 +539,7 @@
             this.comboBoxAccessory3.TabIndex = 22;
             this.comboBoxAccessory3.Text = "Accessory";
             this.comboBoxAccessory3.SelectedIndexChanged += new System.EventHandler(this.comboBoxAccessory_SelectedIndexChanged);
+            this.comboBoxAccessory3.Click += new System.EventHandler(this.comboBoxAccessory_Click);
             // 
             // comboBoxAccessory2
             // 
@@ -538,6 +551,7 @@
             this.comboBoxAccessory2.TabIndex = 14;
             this.comboBoxAccessory2.Text = "Accessory";
             this.comboBoxAccessory2.SelectedIndexChanged += new System.EventHandler(this.comboBoxAccessory_SelectedIndexChanged);
+            this.comboBoxAccessory2.Click += new System.EventHandler(this.comboBoxAccessory_Click);
             // 
             // comboBoxAccessory1
             // 
@@ -549,6 +563,7 @@
             this.comboBoxAccessory1.TabIndex = 6;
             this.comboBoxAccessory1.Text = "Accessory";
             this.comboBoxAccessory1.SelectedIndexChanged += new System.EventHandler(this.comboBoxAccessory_SelectedIndexChanged);
+            this.comboBoxAccessory1.Click += new System.EventHandler(this.comboBoxAccessory_Click);
             // 
             // groupBox1
             // 

--- a/client/UI/FFRKViewPartyPlanner.Designer.cs
+++ b/client/UI/FFRKViewPartyPlanner.Designer.cs
@@ -155,6 +155,11 @@
             this.groupBox12 = new System.Windows.Forms.GroupBox();
             this.groupBox13 = new System.Windows.Forms.GroupBox();
             this.label4 = new System.Windows.Forms.Label();
+            this.buttonSaveParty = new System.Windows.Forms.Button();
+            this.buttonLoadParty = new System.Windows.Forms.Button();
+            this.comboBoxSavedParties = new System.Windows.Forms.ComboBox();
+            this.label5 = new System.Windows.Forms.Label();
+            this.buttonDeleteParty = new System.Windows.Forms.Button();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.groupBox3.SuspendLayout();
@@ -1477,10 +1482,62 @@
             this.label4.Text = "Dropdowns empty?  The game only sends this information the first time you view yo" +
     "ur party screen.  You may need to close and re-open the app.";
             // 
+            // buttonSaveParty
+            // 
+            this.buttonSaveParty.Location = new System.Drawing.Point(575, 460);
+            this.buttonSaveParty.Name = "buttonSaveParty";
+            this.buttonSaveParty.Size = new System.Drawing.Size(75, 23);
+            this.buttonSaveParty.TabIndex = 70;
+            this.buttonSaveParty.Text = "Save";
+            this.buttonSaveParty.UseVisualStyleBackColor = true;
+            this.buttonSaveParty.Click += new System.EventHandler(this.buttonSaveParty_Click);
+            // 
+            // buttonLoadParty
+            // 
+            this.buttonLoadParty.Location = new System.Drawing.Point(656, 460);
+            this.buttonLoadParty.Name = "buttonLoadParty";
+            this.buttonLoadParty.Size = new System.Drawing.Size(75, 23);
+            this.buttonLoadParty.TabIndex = 71;
+            this.buttonLoadParty.Text = "Load";
+            this.buttonLoadParty.UseVisualStyleBackColor = true;
+            this.buttonLoadParty.Click += new System.EventHandler(this.buttonLoadParty_Click);
+            // 
+            // comboBoxSavedParties
+            // 
+            this.comboBoxSavedParties.FormattingEnabled = true;
+            this.comboBoxSavedParties.Location = new System.Drawing.Point(654, 428);
+            this.comboBoxSavedParties.Name = "comboBoxSavedParties";
+            this.comboBoxSavedParties.Size = new System.Drawing.Size(158, 21);
+            this.comboBoxSavedParties.TabIndex = 72;
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(575, 431);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(73, 13);
+            this.label5.TabIndex = 73;
+            this.label5.Text = "Saved Parties";
+            // 
+            // buttonDeleteParty
+            // 
+            this.buttonDeleteParty.Location = new System.Drawing.Point(737, 460);
+            this.buttonDeleteParty.Name = "buttonDeleteParty";
+            this.buttonDeleteParty.Size = new System.Drawing.Size(75, 23);
+            this.buttonDeleteParty.TabIndex = 74;
+            this.buttonDeleteParty.Text = "Delete";
+            this.buttonDeleteParty.UseVisualStyleBackColor = true;
+            this.buttonDeleteParty.Click += new System.EventHandler(this.buttonDeleteParty_Click);
+            // 
             // FFRKViewPartyPlanner
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.buttonDeleteParty);
+            this.Controls.Add(this.label5);
+            this.Controls.Add(this.comboBoxSavedParties);
+            this.Controls.Add(this.buttonLoadParty);
+            this.Controls.Add(this.buttonSaveParty);
             this.Controls.Add(this.label4);
             this.Controls.Add(this.groupBox13);
             this.Controls.Add(this.groupBox12);
@@ -1664,5 +1721,10 @@
         private System.Windows.Forms.GroupBox groupBox12;
         private System.Windows.Forms.GroupBox groupBox13;
         private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Button buttonSaveParty;
+        private System.Windows.Forms.Button buttonLoadParty;
+        private System.Windows.Forms.ComboBox comboBoxSavedParties;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Button buttonDeleteParty;
     }
 }

--- a/client/UI/FFRKViewPartyPlanner.Designer.cs
+++ b/client/UI/FFRKViewPartyPlanner.Designer.cs
@@ -387,181 +387,181 @@
             // 
             // comboBoxWeapon5
             // 
+            this.comboBoxWeapon5.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
             this.comboBoxWeapon5.FormattingEnabled = true;
             this.comboBoxWeapon5.Location = new System.Drawing.Point(6, 436);
             this.comboBoxWeapon5.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.comboBoxWeapon5.Name = "comboBoxWeapon5";
             this.comboBoxWeapon5.Size = new System.Drawing.Size(115, 21);
             this.comboBoxWeapon5.TabIndex = 36;
-            this.comboBoxWeapon5.Text = "Weapon";
             this.comboBoxWeapon5.SelectedIndexChanged += new System.EventHandler(this.comboBoxWeapon_SelectedIndexChanged);
             this.comboBoxWeapon5.Click += new System.EventHandler(this.comboBoxWeapon_Click);
             // 
             // comboBoxWeapon4
             // 
+            this.comboBoxWeapon4.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
             this.comboBoxWeapon4.FormattingEnabled = true;
             this.comboBoxWeapon4.Location = new System.Drawing.Point(6, 338);
             this.comboBoxWeapon4.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.comboBoxWeapon4.Name = "comboBoxWeapon4";
             this.comboBoxWeapon4.Size = new System.Drawing.Size(115, 21);
             this.comboBoxWeapon4.TabIndex = 28;
-            this.comboBoxWeapon4.Text = "Weapon";
             this.comboBoxWeapon4.SelectedIndexChanged += new System.EventHandler(this.comboBoxWeapon_SelectedIndexChanged);
             this.comboBoxWeapon4.Click += new System.EventHandler(this.comboBoxWeapon_Click);
             // 
             // comboBoxWeapon3
             // 
+            this.comboBoxWeapon3.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
             this.comboBoxWeapon3.FormattingEnabled = true;
             this.comboBoxWeapon3.Location = new System.Drawing.Point(6, 238);
             this.comboBoxWeapon3.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.comboBoxWeapon3.Name = "comboBoxWeapon3";
             this.comboBoxWeapon3.Size = new System.Drawing.Size(115, 21);
             this.comboBoxWeapon3.TabIndex = 20;
-            this.comboBoxWeapon3.Text = "Weapon";
             this.comboBoxWeapon3.SelectedIndexChanged += new System.EventHandler(this.comboBoxWeapon_SelectedIndexChanged);
             this.comboBoxWeapon3.Click += new System.EventHandler(this.comboBoxWeapon_Click);
             // 
             // comboBoxWeapon2
             // 
+            this.comboBoxWeapon2.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
             this.comboBoxWeapon2.FormattingEnabled = true;
             this.comboBoxWeapon2.Location = new System.Drawing.Point(6, 139);
             this.comboBoxWeapon2.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.comboBoxWeapon2.Name = "comboBoxWeapon2";
             this.comboBoxWeapon2.Size = new System.Drawing.Size(115, 21);
             this.comboBoxWeapon2.TabIndex = 12;
-            this.comboBoxWeapon2.Text = "Weapon";
             this.comboBoxWeapon2.SelectedIndexChanged += new System.EventHandler(this.comboBoxWeapon_SelectedIndexChanged);
             this.comboBoxWeapon2.Click += new System.EventHandler(this.comboBoxWeapon_Click);
             // 
             // comboBoxWeapon1
             // 
+            this.comboBoxWeapon1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
             this.comboBoxWeapon1.FormattingEnabled = true;
             this.comboBoxWeapon1.Location = new System.Drawing.Point(6, 29);
             this.comboBoxWeapon1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.comboBoxWeapon1.Name = "comboBoxWeapon1";
             this.comboBoxWeapon1.Size = new System.Drawing.Size(115, 21);
             this.comboBoxWeapon1.TabIndex = 4;
-            this.comboBoxWeapon1.Text = "Weapon";
             this.comboBoxWeapon1.SelectedIndexChanged += new System.EventHandler(this.comboBoxWeapon_SelectedIndexChanged);
             this.comboBoxWeapon1.Click += new System.EventHandler(this.comboBoxWeapon_Click);
             // 
             // comboBoxArmor5
             // 
+            this.comboBoxArmor5.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
             this.comboBoxArmor5.FormattingEnabled = true;
             this.comboBoxArmor5.Location = new System.Drawing.Point(6, 465);
             this.comboBoxArmor5.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.comboBoxArmor5.Name = "comboBoxArmor5";
             this.comboBoxArmor5.Size = new System.Drawing.Size(115, 21);
             this.comboBoxArmor5.TabIndex = 37;
-            this.comboBoxArmor5.Text = "Armor";
             this.comboBoxArmor5.SelectedIndexChanged += new System.EventHandler(this.comboBoxArmor_SelectedIndexChanged);
             this.comboBoxArmor5.Click += new System.EventHandler(this.comboBoxArmor_Click);
             // 
             // comboBoxArmor4
             // 
+            this.comboBoxArmor4.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
             this.comboBoxArmor4.FormattingEnabled = true;
             this.comboBoxArmor4.Location = new System.Drawing.Point(6, 367);
             this.comboBoxArmor4.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.comboBoxArmor4.Name = "comboBoxArmor4";
             this.comboBoxArmor4.Size = new System.Drawing.Size(115, 21);
             this.comboBoxArmor4.TabIndex = 29;
-            this.comboBoxArmor4.Text = "Armor";
             this.comboBoxArmor4.SelectedIndexChanged += new System.EventHandler(this.comboBoxArmor_SelectedIndexChanged);
             this.comboBoxArmor4.Click += new System.EventHandler(this.comboBoxArmor_Click);
             // 
             // comboBoxArmor3
             // 
+            this.comboBoxArmor3.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
             this.comboBoxArmor3.FormattingEnabled = true;
             this.comboBoxArmor3.Location = new System.Drawing.Point(6, 267);
             this.comboBoxArmor3.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.comboBoxArmor3.Name = "comboBoxArmor3";
             this.comboBoxArmor3.Size = new System.Drawing.Size(115, 21);
             this.comboBoxArmor3.TabIndex = 21;
-            this.comboBoxArmor3.Text = "Armor";
             this.comboBoxArmor3.SelectedIndexChanged += new System.EventHandler(this.comboBoxArmor_SelectedIndexChanged);
             this.comboBoxArmor3.Click += new System.EventHandler(this.comboBoxArmor_Click);
             // 
             // comboBoxArmor2
             // 
+            this.comboBoxArmor2.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
             this.comboBoxArmor2.FormattingEnabled = true;
             this.comboBoxArmor2.Location = new System.Drawing.Point(6, 168);
             this.comboBoxArmor2.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.comboBoxArmor2.Name = "comboBoxArmor2";
             this.comboBoxArmor2.Size = new System.Drawing.Size(115, 21);
             this.comboBoxArmor2.TabIndex = 13;
-            this.comboBoxArmor2.Text = "Armor";
             this.comboBoxArmor2.SelectedIndexChanged += new System.EventHandler(this.comboBoxArmor_SelectedIndexChanged);
             this.comboBoxArmor2.Click += new System.EventHandler(this.comboBoxArmor_Click);
             // 
             // comboBoxArmor1
             // 
+            this.comboBoxArmor1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
             this.comboBoxArmor1.FormattingEnabled = true;
             this.comboBoxArmor1.Location = new System.Drawing.Point(6, 58);
             this.comboBoxArmor1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.comboBoxArmor1.Name = "comboBoxArmor1";
             this.comboBoxArmor1.Size = new System.Drawing.Size(115, 21);
             this.comboBoxArmor1.TabIndex = 5;
-            this.comboBoxArmor1.Text = "Armor";
             this.comboBoxArmor1.SelectedIndexChanged += new System.EventHandler(this.comboBoxArmor_SelectedIndexChanged);
             this.comboBoxArmor1.Click += new System.EventHandler(this.comboBoxArmor_Click);
             // 
             // comboBoxAccessory5
             // 
+            this.comboBoxAccessory5.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
             this.comboBoxAccessory5.FormattingEnabled = true;
             this.comboBoxAccessory5.Location = new System.Drawing.Point(6, 494);
             this.comboBoxAccessory5.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.comboBoxAccessory5.Name = "comboBoxAccessory5";
             this.comboBoxAccessory5.Size = new System.Drawing.Size(115, 21);
             this.comboBoxAccessory5.TabIndex = 38;
-            this.comboBoxAccessory5.Text = "Accessory";
             this.comboBoxAccessory5.SelectedIndexChanged += new System.EventHandler(this.comboBoxAccessory_SelectedIndexChanged);
             this.comboBoxAccessory5.Click += new System.EventHandler(this.comboBoxAccessory_Click);
             // 
             // comboBoxAccessory4
             // 
+            this.comboBoxAccessory4.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
             this.comboBoxAccessory4.FormattingEnabled = true;
             this.comboBoxAccessory4.Location = new System.Drawing.Point(6, 396);
             this.comboBoxAccessory4.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.comboBoxAccessory4.Name = "comboBoxAccessory4";
             this.comboBoxAccessory4.Size = new System.Drawing.Size(115, 21);
             this.comboBoxAccessory4.TabIndex = 30;
-            this.comboBoxAccessory4.Text = "Accessory";
             this.comboBoxAccessory4.SelectedIndexChanged += new System.EventHandler(this.comboBoxAccessory_SelectedIndexChanged);
             this.comboBoxAccessory4.Click += new System.EventHandler(this.comboBoxAccessory_Click);
             // 
             // comboBoxAccessory3
             // 
+            this.comboBoxAccessory3.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
             this.comboBoxAccessory3.FormattingEnabled = true;
             this.comboBoxAccessory3.Location = new System.Drawing.Point(6, 296);
             this.comboBoxAccessory3.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.comboBoxAccessory3.Name = "comboBoxAccessory3";
             this.comboBoxAccessory3.Size = new System.Drawing.Size(115, 21);
             this.comboBoxAccessory3.TabIndex = 22;
-            this.comboBoxAccessory3.Text = "Accessory";
             this.comboBoxAccessory3.SelectedIndexChanged += new System.EventHandler(this.comboBoxAccessory_SelectedIndexChanged);
             this.comboBoxAccessory3.Click += new System.EventHandler(this.comboBoxAccessory_Click);
             // 
             // comboBoxAccessory2
             // 
+            this.comboBoxAccessory2.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
             this.comboBoxAccessory2.FormattingEnabled = true;
             this.comboBoxAccessory2.Location = new System.Drawing.Point(6, 197);
             this.comboBoxAccessory2.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.comboBoxAccessory2.Name = "comboBoxAccessory2";
             this.comboBoxAccessory2.Size = new System.Drawing.Size(115, 21);
             this.comboBoxAccessory2.TabIndex = 14;
-            this.comboBoxAccessory2.Text = "Accessory";
             this.comboBoxAccessory2.SelectedIndexChanged += new System.EventHandler(this.comboBoxAccessory_SelectedIndexChanged);
             this.comboBoxAccessory2.Click += new System.EventHandler(this.comboBoxAccessory_Click);
             // 
             // comboBoxAccessory1
             // 
+            this.comboBoxAccessory1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
             this.comboBoxAccessory1.FormattingEnabled = true;
             this.comboBoxAccessory1.Location = new System.Drawing.Point(6, 87);
             this.comboBoxAccessory1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.comboBoxAccessory1.Name = "comboBoxAccessory1";
             this.comboBoxAccessory1.Size = new System.Drawing.Size(115, 21);
             this.comboBoxAccessory1.TabIndex = 6;
-            this.comboBoxAccessory1.Text = "Accessory";
             this.comboBoxAccessory1.SelectedIndexChanged += new System.EventHandler(this.comboBoxAccessory_SelectedIndexChanged);
             this.comboBoxAccessory1.Click += new System.EventHandler(this.comboBoxAccessory_Click);
             // 

--- a/client/UI/FFRKViewPartyPlanner.Designer.cs
+++ b/client/UI/FFRKViewPartyPlanner.Designer.cs
@@ -394,6 +394,7 @@
             this.comboBoxWeapon5.Name = "comboBoxWeapon5";
             this.comboBoxWeapon5.Size = new System.Drawing.Size(115, 21);
             this.comboBoxWeapon5.TabIndex = 36;
+            this.comboBoxWeapon5.Text = "Weapon";
             this.comboBoxWeapon5.SelectedIndexChanged += new System.EventHandler(this.comboBoxWeapon_SelectedIndexChanged);
             this.comboBoxWeapon5.Click += new System.EventHandler(this.comboBoxWeapon_Click);
             // 
@@ -406,6 +407,7 @@
             this.comboBoxWeapon4.Name = "comboBoxWeapon4";
             this.comboBoxWeapon4.Size = new System.Drawing.Size(115, 21);
             this.comboBoxWeapon4.TabIndex = 28;
+            this.comboBoxWeapon4.Text = "Weapon";
             this.comboBoxWeapon4.SelectedIndexChanged += new System.EventHandler(this.comboBoxWeapon_SelectedIndexChanged);
             this.comboBoxWeapon4.Click += new System.EventHandler(this.comboBoxWeapon_Click);
             // 
@@ -418,6 +420,7 @@
             this.comboBoxWeapon3.Name = "comboBoxWeapon3";
             this.comboBoxWeapon3.Size = new System.Drawing.Size(115, 21);
             this.comboBoxWeapon3.TabIndex = 20;
+            this.comboBoxWeapon3.Text = "Weapon";
             this.comboBoxWeapon3.SelectedIndexChanged += new System.EventHandler(this.comboBoxWeapon_SelectedIndexChanged);
             this.comboBoxWeapon3.Click += new System.EventHandler(this.comboBoxWeapon_Click);
             // 
@@ -430,6 +433,7 @@
             this.comboBoxWeapon2.Name = "comboBoxWeapon2";
             this.comboBoxWeapon2.Size = new System.Drawing.Size(115, 21);
             this.comboBoxWeapon2.TabIndex = 12;
+            this.comboBoxWeapon2.Text = "Weapon";
             this.comboBoxWeapon2.SelectedIndexChanged += new System.EventHandler(this.comboBoxWeapon_SelectedIndexChanged);
             this.comboBoxWeapon2.Click += new System.EventHandler(this.comboBoxWeapon_Click);
             // 
@@ -442,6 +446,7 @@
             this.comboBoxWeapon1.Name = "comboBoxWeapon1";
             this.comboBoxWeapon1.Size = new System.Drawing.Size(115, 21);
             this.comboBoxWeapon1.TabIndex = 4;
+            this.comboBoxWeapon1.Text = "Weapon";
             this.comboBoxWeapon1.SelectedIndexChanged += new System.EventHandler(this.comboBoxWeapon_SelectedIndexChanged);
             this.comboBoxWeapon1.Click += new System.EventHandler(this.comboBoxWeapon_Click);
             // 
@@ -454,6 +459,7 @@
             this.comboBoxArmor5.Name = "comboBoxArmor5";
             this.comboBoxArmor5.Size = new System.Drawing.Size(115, 21);
             this.comboBoxArmor5.TabIndex = 37;
+            this.comboBoxArmor5.Text = "Armor";
             this.comboBoxArmor5.SelectedIndexChanged += new System.EventHandler(this.comboBoxArmor_SelectedIndexChanged);
             this.comboBoxArmor5.Click += new System.EventHandler(this.comboBoxArmor_Click);
             // 
@@ -466,6 +472,7 @@
             this.comboBoxArmor4.Name = "comboBoxArmor4";
             this.comboBoxArmor4.Size = new System.Drawing.Size(115, 21);
             this.comboBoxArmor4.TabIndex = 29;
+            this.comboBoxArmor4.Text = "Armor";
             this.comboBoxArmor4.SelectedIndexChanged += new System.EventHandler(this.comboBoxArmor_SelectedIndexChanged);
             this.comboBoxArmor4.Click += new System.EventHandler(this.comboBoxArmor_Click);
             // 
@@ -478,6 +485,7 @@
             this.comboBoxArmor3.Name = "comboBoxArmor3";
             this.comboBoxArmor3.Size = new System.Drawing.Size(115, 21);
             this.comboBoxArmor3.TabIndex = 21;
+            this.comboBoxArmor3.Text = "Armor";
             this.comboBoxArmor3.SelectedIndexChanged += new System.EventHandler(this.comboBoxArmor_SelectedIndexChanged);
             this.comboBoxArmor3.Click += new System.EventHandler(this.comboBoxArmor_Click);
             // 
@@ -490,6 +498,7 @@
             this.comboBoxArmor2.Name = "comboBoxArmor2";
             this.comboBoxArmor2.Size = new System.Drawing.Size(115, 21);
             this.comboBoxArmor2.TabIndex = 13;
+            this.comboBoxArmor2.Text = "Armor";
             this.comboBoxArmor2.SelectedIndexChanged += new System.EventHandler(this.comboBoxArmor_SelectedIndexChanged);
             this.comboBoxArmor2.Click += new System.EventHandler(this.comboBoxArmor_Click);
             // 
@@ -502,6 +511,7 @@
             this.comboBoxArmor1.Name = "comboBoxArmor1";
             this.comboBoxArmor1.Size = new System.Drawing.Size(115, 21);
             this.comboBoxArmor1.TabIndex = 5;
+            this.comboBoxArmor1.Text = "Armor";
             this.comboBoxArmor1.SelectedIndexChanged += new System.EventHandler(this.comboBoxArmor_SelectedIndexChanged);
             this.comboBoxArmor1.Click += new System.EventHandler(this.comboBoxArmor_Click);
             // 
@@ -514,6 +524,7 @@
             this.comboBoxAccessory5.Name = "comboBoxAccessory5";
             this.comboBoxAccessory5.Size = new System.Drawing.Size(115, 21);
             this.comboBoxAccessory5.TabIndex = 38;
+            this.comboBoxAccessory5.Text = "Accessory";
             this.comboBoxAccessory5.SelectedIndexChanged += new System.EventHandler(this.comboBoxAccessory_SelectedIndexChanged);
             this.comboBoxAccessory5.Click += new System.EventHandler(this.comboBoxAccessory_Click);
             // 
@@ -526,6 +537,7 @@
             this.comboBoxAccessory4.Name = "comboBoxAccessory4";
             this.comboBoxAccessory4.Size = new System.Drawing.Size(115, 21);
             this.comboBoxAccessory4.TabIndex = 30;
+            this.comboBoxAccessory4.Text = "Accessory";
             this.comboBoxAccessory4.SelectedIndexChanged += new System.EventHandler(this.comboBoxAccessory_SelectedIndexChanged);
             this.comboBoxAccessory4.Click += new System.EventHandler(this.comboBoxAccessory_Click);
             // 
@@ -538,6 +550,7 @@
             this.comboBoxAccessory3.Name = "comboBoxAccessory3";
             this.comboBoxAccessory3.Size = new System.Drawing.Size(115, 21);
             this.comboBoxAccessory3.TabIndex = 22;
+            this.comboBoxAccessory3.Text = "Accessory";
             this.comboBoxAccessory3.SelectedIndexChanged += new System.EventHandler(this.comboBoxAccessory_SelectedIndexChanged);
             this.comboBoxAccessory3.Click += new System.EventHandler(this.comboBoxAccessory_Click);
             // 
@@ -550,6 +563,7 @@
             this.comboBoxAccessory2.Name = "comboBoxAccessory2";
             this.comboBoxAccessory2.Size = new System.Drawing.Size(115, 21);
             this.comboBoxAccessory2.TabIndex = 14;
+            this.comboBoxAccessory2.Text = "Accessory";
             this.comboBoxAccessory2.SelectedIndexChanged += new System.EventHandler(this.comboBoxAccessory_SelectedIndexChanged);
             this.comboBoxAccessory2.Click += new System.EventHandler(this.comboBoxAccessory_Click);
             // 
@@ -562,6 +576,7 @@
             this.comboBoxAccessory1.Name = "comboBoxAccessory1";
             this.comboBoxAccessory1.Size = new System.Drawing.Size(115, 21);
             this.comboBoxAccessory1.TabIndex = 6;
+            this.comboBoxAccessory1.Text = "Accessory";
             this.comboBoxAccessory1.SelectedIndexChanged += new System.EventHandler(this.comboBoxAccessory_SelectedIndexChanged);
             this.comboBoxAccessory1.Click += new System.EventHandler(this.comboBoxAccessory_Click);
             // 

--- a/client/UI/FFRKViewPartyPlanner.cs
+++ b/client/UI/FFRKViewPartyPlanner.cs
@@ -914,6 +914,7 @@ namespace FFRKInspector.UI
             if (equipmentModal.ShowDialog(this) == DialogResult.OK)
             {
                 SelectEquipment((ComboBox)sender, equipmentModal.SelectedInstanceId);
+                ((ComboBox)sender).Select(0, 0);
             }
         }
 
@@ -941,6 +942,7 @@ namespace FFRKInspector.UI
             if (equipmentModal.ShowDialog(this) == DialogResult.OK)
             {
                 SelectEquipment((ComboBox)sender, equipmentModal.SelectedInstanceId);
+                ((ComboBox)sender).Select(0, 0);
             }
         }
 
@@ -968,6 +970,7 @@ namespace FFRKInspector.UI
             if (equipmentModal.ShowDialog(this) == DialogResult.OK)
             {
                 SelectEquipment((ComboBox)sender, equipmentModal.SelectedInstanceId);
+                ((ComboBox)sender).Select(0, 0);
             }
         }
     }

--- a/client/UI/FFRKViewPartyPlanner.cs
+++ b/client/UI/FFRKViewPartyPlanner.cs
@@ -1186,7 +1186,6 @@ namespace FFRKInspector.UI
                 {
                     weaponBoxes[i].SelectedIndex = -1;
                     weaponBoxes[i].Text = "Weapon";
-                    weaponBoxes[i].Items.Clear();
                 }
 
                 if (member["armorId"] > 0)
@@ -1204,7 +1203,6 @@ namespace FFRKInspector.UI
                 {
                     armorBoxes[i].SelectedIndex = -1;
                     armorBoxes[i].Text = "Armor";
-                    armorBoxes[i].Items.Clear();
                 }
 
                 if (member["accessoryId"] > 0)
@@ -1222,7 +1220,6 @@ namespace FFRKInspector.UI
                 {
                     accessoryBoxes[i].SelectedIndex = -1;
                     accessoryBoxes[i].Text = "Accessory";
-                    accessoryBoxes[i].Items.Clear();
                 }
 
                 if (member["recordMateriaId"] > 0)
@@ -1257,7 +1254,6 @@ namespace FFRKInspector.UI
                 {
                     abilityBoxes[i * 2].SelectedIndex = -1;
                     abilityBoxes[i * 2].Text = "Ability";
-                    abilityBoxes[i * 2].Items.Clear();
                 }
 
                 if (member["ability2Id"] > 0)
@@ -1275,7 +1271,6 @@ namespace FFRKInspector.UI
                 {
                     abilityBoxes[i * 2 + 1].SelectedIndex = -1;
                     abilityBoxes[i * 2 + 1].Text = "Ability";
-                    abilityBoxes[i * 2 + 1].Items.Clear();
                 }
 
                 if (member["soulBreakId"] > 0)
@@ -1293,7 +1288,6 @@ namespace FFRKInspector.UI
                 {
                     soulBreakBoxes[i].SelectedIndex = -1;
                     soulBreakBoxes[i].Text = "Soul Break";
-                    soulBreakBoxes[i].Items.Clear();
                 }
             }
 

--- a/client/UI/FFRKViewPartyPlanner.cs
+++ b/client/UI/FFRKViewPartyPlanner.cs
@@ -355,13 +355,13 @@ namespace FFRKInspector.UI
         private void RecalculateAllStats()
         {
             textBoxEnemyEffectiveDef.Text = Math.Ceiling(Double.Parse(textBoxEnemyDef.Text) *
-                DebuffedDefMultiplier(1
+                DebuffedDefensiveMultiplier(1
                 * (checkBoxFullBreak.Checked ? (checkBoxArmorBreakResistant.Checked ? 0.85 : 0.7) : 1)
                 * (checkBoxArmorBreakdown.Checked ? (checkBoxArmorBreakResistant.Checked ? 0.8 : 0.6) : 1)
                 * (checkBoxBanishingBlade.Checked ? (checkBoxArmorBreakResistant.Checked ? 0.75 : 0.5) : 1))).ToString();
 
             textBoxEnemyEffectiveRes.Text = Math.Ceiling(Double.Parse(textBoxEnemyRes.Text) *
-                DebuffedResMultiplier(1
+                DebuffedDefensiveMultiplier(1
                 * (checkBoxFullBreak.Checked ? (checkBoxMentalBreakResistant.Checked ? 0.85 : 0.7) : 1)
                 * (checkBoxMentalBreakdown.Checked ? (checkBoxMentalBreakResistant.Checked ? 0.75 : 0.5) : 1))).ToString();
             
@@ -371,17 +371,27 @@ namespace FFRKInspector.UI
             }
         }
 
-        private double DebuffedDefMultiplier(double multiplier)
+        private double BuffedOffensiveMultiplier(double multiplier)
         {
-            if (multiplier >= 0.3)
+            if (multiplier <= 2.5)
             {
                 return multiplier;
             }
-            double newMultiplier = 0.3 - 1.5 * Math.Log10(1 + (0.3 - multiplier));
-            return Math.Max(newMultiplier, 0.2);
+            double newMultiplier = 2.5 + 0.3 * Math.Log(1 + (multiplier - 2.5));
+            return Math.Min(3, newMultiplier);
         }
 
-        private double DebuffedResMultiplier(double multiplier)
+        private double BuffedDefensiveMultiplier(double multiplier)
+        {
+            if (multiplier <= 4.5)
+            {
+                return multiplier;
+            }
+            double newMultiplier = 4.5 + 1.05 * Math.Log(1 + (multiplier - 4.5));
+            return Math.Min(9, newMultiplier);
+        }
+
+        private double DebuffedOffensiveMultiplier(double multiplier)
         {
             if (multiplier >= 0.35)
             {
@@ -389,6 +399,16 @@ namespace FFRKInspector.UI
             }
             double newMultiplier = 0.35 - 1.1 * Math.Log10(1 + (0.35 - multiplier));
             return Math.Max(newMultiplier, 0.3);
+        }
+
+        private double DebuffedDefensiveMultiplier(double multiplier)
+        {
+            if (multiplier >= 0.3)
+            {
+                return multiplier;
+            }
+            double newMultiplier = 0.3 - 1.5 * Math.Log10(1 + (0.3 - multiplier));
+            return Math.Max(newMultiplier, 0.2);
         }
         
         private void RecalculateStats(int characterIndex)
@@ -453,39 +473,34 @@ namespace FFRKInspector.UI
                 (accessory != null ? accessory.StatWithSynergy("HP", accessoryHasSynergy) : 0)).ToString("#,##0.##");
 
             atkFields[characterIndex].Text = (
-                ((character != null ? (characterHasSynergy ? character.SeriesAtk : character.Atk) : 0) +
+                (character != null ? (characterHasSynergy ? character.SeriesAtk : character.Atk) : 0) +
                 (weapon != null ? weapon.StatWithSynergy("Atk", weaponHasSynergy) : 0) +
                 (armor != null ? armor.StatWithSynergy("Atk", armorHasSynergy) : 0) +
-                (accessory != null ? accessory.StatWithSynergy("Atk", accessoryHasSynergy) : 0))
-                * (recordMateria != null ? recordMateria.AtkModifier(weapon, armor, accessory) : 1)).ToString("#,##0.##");
+                (accessory != null ? accessory.StatWithSynergy("Atk", accessoryHasSynergy) : 0)).ToString("#,##0.##");
 
             magFields[characterIndex].Text = (
                 (character != null ? (characterHasSynergy ? character.SeriesMag : character.Mag) : 0) +
                 (weapon != null ? weapon.StatWithSynergy("Mag", weaponHasSynergy) : 0) +
                 (armor != null ? armor.StatWithSynergy("Mag", armorHasSynergy) : 0) +
-                (accessory != null ? accessory.StatWithSynergy("Mag", accessoryHasSynergy) : 0)
-                * (recordMateria != null ? recordMateria.MagModifier(weapon, armor, accessory) : 1)).ToString("#,##0.##");
+                (accessory != null ? accessory.StatWithSynergy("Mag", accessoryHasSynergy) : 0)).ToString("#,##0.##");
 
             mndFields[characterIndex].Text = (
                 (character != null ? (characterHasSynergy ? character.SeriesMag : character.Mag) : 0) +
                 (weapon != null ? weapon.StatWithSynergy("Mnd", weaponHasSynergy) : 0) +
                 (armor != null ? armor.StatWithSynergy("Mnd", armorHasSynergy) : 0) +
-                (accessory != null ? accessory.StatWithSynergy("Mnd", accessoryHasSynergy) : 0)
-                * (recordMateria != null ? recordMateria.MndModifier(weapon, armor, accessory) : 1)).ToString("#,##0.##");
+                (accessory != null ? accessory.StatWithSynergy("Mnd", accessoryHasSynergy) : 0)).ToString("#,##0.##");
 
             defFields[characterIndex].Text = (
                 (character != null ? (characterHasSynergy ? character.SeriesDef : character.Def) : 0) +
                 (weapon != null ? weapon.StatWithSynergy("Def", weaponHasSynergy) : 0) +
                 (armor != null ? armor.StatWithSynergy("Def", armorHasSynergy) : 0) +
-                (accessory != null ? accessory.StatWithSynergy("Def", accessoryHasSynergy) : 0)
-                * (recordMateria != null ? recordMateria.DefModifier(weapon, armor, accessory) : 1)).ToString("#,##0.##");
+                (accessory != null ? accessory.StatWithSynergy("Def", accessoryHasSynergy) : 0)).ToString("#,##0.##");
 
             resFields[characterIndex].Text = (
                 (character != null ? (characterHasSynergy ? character.SeriesRes : character.Res) : 0) +
                 (weapon != null ? weapon.StatWithSynergy("Res", weaponHasSynergy) : 0) +
                 (armor != null ? armor.StatWithSynergy("Res", armorHasSynergy) : 0) +
-                (accessory != null ? accessory.StatWithSynergy("Res", accessoryHasSynergy) : 0)
-                * (recordMateria != null ? recordMateria.ResModifier(weapon, armor, accessory) : 1)).ToString("#,##0.##");
+                (accessory != null ? accessory.StatWithSynergy("Res", accessoryHasSynergy) : 0)).ToString("#,##0.##");
 
             evaFields[characterIndex].Text = (
                 (character != null ? (characterHasSynergy ? character.SeriesEva : character.Eva) : 0) +
@@ -499,37 +514,49 @@ namespace FFRKInspector.UI
                 (armor != null ? armor.StatWithSynergy("Spd", armorHasSynergy) : 0) +
                 (accessory != null ? accessory.StatWithSynergy("Spd", accessoryHasSynergy) : 0)).ToString("#,##0.##");
 
+            double atkMultiplier = (recordMateria != null ? recordMateria.AtkModifier(weapon, armor, accessory) : 1);
+            double magMultiplier = (recordMateria != null ? recordMateria.MagModifier(weapon, armor, accessory) : 1);
+            double mndMultiplier = (recordMateria != null ? recordMateria.MndModifier(weapon, armor, accessory) : 1);
+            double defMultiplier = (recordMateria != null ? recordMateria.DefModifier(weapon, armor, accessory) : 1);
+            double resMultiplier = (recordMateria != null ? recordMateria.ResModifier(weapon, armor, accessory) : 1);
+
             if(recordMateria != null && (recordMateria.RecordMateriaId == 111070100 || recordMateria.RecordMateriaId == 111080060))
             {
                 // Loner or Solitude
                 for(int i = 0; i < characterBoxes.Count(box => box.SelectedItem == null); i++)
                 {
-                    atkFields[characterIndex].Text = Math.Floor(Double.Parse(atkFields[characterIndex].Text) * 1.1).ToString("#,##0.##");
-                    defFields[characterIndex].Text = Math.Floor(Double.Parse(defFields[characterIndex].Text) * 1.1).ToString("#,##0.##");
+                    atkMultiplier *= 1.1;
+                    defMultiplier *= 1.1;
                 }
             }
 
             if (checkBoxShout.Checked)
             {
-                atkFields[characterIndex].Text = (Double.Parse(atkFields[characterIndex].Text) * 1.5).ToString("#,##0.##");
+                atkMultiplier *= 1.5;
             }
 
             if (checkBoxHotE.Checked)
             {
-                atkFields[characterIndex].Text = (Double.Parse(atkFields[characterIndex].Text) * 1.3).ToString("#,##0.##");
-                defFields[characterIndex].Text = (Double.Parse(defFields[characterIndex].Text) * 1.3).ToString("#,##0.##");
+                atkMultiplier *= 1.3;
+                defMultiplier *= 1.3;
             }
 
             if (checkBoxFocus.Checked)
             {
-                magFields[characterIndex].Text = (Double.Parse(magFields[characterIndex].Text) * 1.2).ToString("#,##0.##");
-                resFields[characterIndex].Text = (Double.Parse(resFields[characterIndex].Text) * 1.5).ToString("#,##0.##");
+                magMultiplier *= 1.2;
+                resMultiplier *= 1.5;
             }
 
             if (checkBoxFaith.Checked)
             {
-                magFields[characterIndex].Text = (Double.Parse(magFields[characterIndex].Text) * 1.2).ToString("#,##0.##");
+                magMultiplier *= 1.2;
             }
+
+            atkFields[characterIndex].Text = (Double.Parse(atkFields[characterIndex].Text) * BuffedOffensiveMultiplier(atkMultiplier)).ToString("#,##0.##");
+            magFields[characterIndex].Text = (Double.Parse(magFields[characterIndex].Text) * BuffedOffensiveMultiplier(magMultiplier)).ToString("#,##0.##");
+            mndFields[characterIndex].Text = (Double.Parse(mndFields[characterIndex].Text) * BuffedOffensiveMultiplier(mndMultiplier)).ToString("#,##0.##");
+            defFields[characterIndex].Text = (Double.Parse(defFields[characterIndex].Text) * BuffedDefensiveMultiplier(defMultiplier)).ToString("#,##0.##");
+            resFields[characterIndex].Text = (Double.Parse(resFields[characterIndex].Text) * BuffedDefensiveMultiplier(resMultiplier)).ToString("#,##0.##");
 
             if (abilities[characterIndex * 2] != null)
             {

--- a/client/UI/FFRKViewPartyPlanner.cs
+++ b/client/UI/FFRKViewPartyPlanner.cs
@@ -916,7 +916,12 @@ namespace FFRKInspector.UI
 
         private void comboBoxAbility_SelectedIndexChanged(object sender, EventArgs e)
         {
-            RecalculateStats((Int32.Parse(((ComboBox)sender).Name.Last().ToString()) - 1) / 2);
+            int index = (Int32.Parse(((ComboBox)sender).Name.Last().ToString())) - 1;
+            if(index == -1)
+            {
+                index = 9;
+            }
+            RecalculateStats(index / 2);
         }
 
         private void textBoxEnemyStats_TextChanged(object sender, EventArgs e)

--- a/client/UI/FFRKViewPartyPlanner.cs
+++ b/client/UI/FFRKViewPartyPlanner.cs
@@ -32,8 +32,9 @@ namespace FFRKInspector.UI
         private TextBox[] spdFields = new TextBox[5];
         private TextBox[] abilityDamageFields = new TextBox[10];
         private TextBox[] soulBreakDamageFields = new TextBox[5];
+        private EquipmentSelectorModal equipmentModal = new EquipmentSelectorModal();
 
-        private class Synergy
+        public class Synergy
         {
             public Synergy(string name, uint seriesId, GameData.SchemaConstants.AbilityCategory nightmareCategory)
             {
@@ -176,6 +177,8 @@ namespace FFRKInspector.UI
             comboBoxRealmSynergy.Items.Add(new Synergy("Tetra Foul Nightmare", 405001, GameData.SchemaConstants.AbilityCategory.Support));
             comboBoxRealmSynergy.Items.Add(new Synergy("Northern Cross Nightmare", 406001, GameData.SchemaConstants.AbilityCategory.Celerity));
             comboBoxRealmSynergy.Items.Add(new Synergy("Meltdown Nightmare", 407001, GameData.SchemaConstants.AbilityCategory.BlackMagic));
+
+            equipmentModal.UpdateRealmSynergies(comboBoxRealmSynergy.Items);
         }
 
         private void FFRKViewPartyPlanner_Load(object sender, EventArgs e)
@@ -796,6 +799,15 @@ namespace FFRKInspector.UI
 
             RecalculateStats(index);
         }
+
+        private ComboBox mCurrentEquipmentList = null;
+
+        private void UpdateEquipmentGrid(GameData.DataBuddyInformation character, ComboBox equipmentList, List<uint> equippedItems)
+        {
+            mCurrentEquipmentList = equipmentList;
+            equipmentModal.UpdateEquipmentGrid(character, equipmentList, equippedItems, RealmSynergy);
+        }
+
         private void comboBoxPartyMember_SelectedIndexChanged(object sender, EventArgs e)
         {
             int index = Int32.Parse(((ComboBox)sender).Name.Last().ToString()) - 1;
@@ -864,6 +876,99 @@ namespace FFRKInspector.UI
         private void checkBoxDebuff_CheckedChanged(object sender, EventArgs e)
         {
             RecalculateAllStats();
+        }
+
+        private void SelectEquipment(ComboBox equipmentList, uint instanceId)
+        {
+            for (int i = 0; i < equipmentList.Items.Count; i++)
+            {
+                if (((DataEquipmentInformation)equipmentList.Items[i]).InstanceId == instanceId)
+                {
+                    equipmentList.SelectedIndex = i;
+                    return;
+                }
+            }
+        }
+        
+        private void comboBoxWeapon_Click(object sender, EventArgs e)
+        {
+            if(((ComboBox)sender).Items.Count == 0)
+            {
+                return;
+            }
+            int index = Int32.Parse(((ComboBox)sender).Name.Last().ToString()) - 1;
+            GameData.DataBuddyInformation character = characters[index];
+            List<uint> equippedItems = new List<uint>();
+            for (int i = 0; i < 5; i++)
+            {
+                if (i == index)
+                {
+                    continue;
+                }
+                if (weaponBoxes[i].SelectedItem != null)
+                {
+                    equippedItems.Add(((DataEquipmentInformation)weaponBoxes[i].SelectedItem).InstanceId);
+                }
+            }
+            UpdateEquipmentGrid(character, (ComboBox)sender, equippedItems);
+            if (equipmentModal.ShowDialog(this) == DialogResult.OK)
+            {
+                SelectEquipment((ComboBox)sender, equipmentModal.SelectedInstanceId);
+            }
+        }
+
+        private void comboBoxArmor_Click(object sender, EventArgs e)
+        {
+            if (((ComboBox)sender).Items.Count == 0)
+            {
+                return;
+            }
+            int index = Int32.Parse(((ComboBox)sender).Name.Last().ToString()) - 1;
+            GameData.DataBuddyInformation character = characters[index];
+            List<uint> equippedItems = new List<uint>();
+            for (int i = 0; i < 5; i++)
+            {
+                if (i == index)
+                {
+                    continue;
+                }
+                if (armorBoxes[i].SelectedItem != null)
+                {
+                    equippedItems.Add(((DataEquipmentInformation)armorBoxes[i].SelectedItem).InstanceId);
+                }
+            }
+            UpdateEquipmentGrid(character, (ComboBox)sender, equippedItems);
+            if (equipmentModal.ShowDialog(this) == DialogResult.OK)
+            {
+                SelectEquipment((ComboBox)sender, equipmentModal.SelectedInstanceId);
+            }
+        }
+
+        private void comboBoxAccessory_Click(object sender, EventArgs e)
+        {
+            if (((ComboBox)sender).Items.Count == 0)
+            {
+                return;
+            }
+            int index = Int32.Parse(((ComboBox)sender).Name.Last().ToString()) - 1;
+            GameData.DataBuddyInformation character = characters[index];
+            List<uint> equippedItems = new List<uint>();
+            for (int i = 0; i < 5; i++)
+            {
+                if (i == index)
+                {
+                    continue;
+                }
+                if (accessoryBoxes[i].SelectedItem != null)
+                {
+                    equippedItems.Add(((DataEquipmentInformation)accessoryBoxes[i].SelectedItem).InstanceId);
+                }
+            }
+            UpdateEquipmentGrid(character, (ComboBox)sender, equippedItems);
+            if (equipmentModal.ShowDialog(this) == DialogResult.OK)
+            {
+                SelectEquipment((ComboBox)sender, equipmentModal.SelectedInstanceId);
+            }
         }
     }
 }

--- a/client/UI/TextInput.Designer.cs
+++ b/client/UI/TextInput.Designer.cs
@@ -1,0 +1,105 @@
+﻿namespace FFRKInspector.UI
+{
+    partial class TextInput
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.label1 = new System.Windows.Forms.Label();
+            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.buttonOk = new System.Windows.Forms.Button();
+            this.buttonCancel = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(12, 9);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(346, 13);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Enter a new party name or the same name to overwrite an existing party.";
+            // 
+            // textBox1
+            // 
+            this.textBox1.Location = new System.Drawing.Point(15, 28);
+            this.textBox1.Name = "textBox1";
+            this.textBox1.Size = new System.Drawing.Size(343, 20);
+            this.textBox1.TabIndex = 1;
+            // 
+            // buttonOk
+            // 
+            this.buttonOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonOk.Location = new System.Drawing.Point(204, 58);
+            this.buttonOk.Name = "buttonOk";
+            this.buttonOk.Size = new System.Drawing.Size(75, 23);
+            this.buttonOk.TabIndex = 2;
+            this.buttonOk.Text = "OK";
+            this.buttonOk.UseVisualStyleBackColor = true;
+            this.buttonOk.Click += new System.EventHandler(this.buttonOk_Click);
+            // 
+            // buttonCancel
+            // 
+            this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.buttonCancel.Location = new System.Drawing.Point(285, 58);
+            this.buttonCancel.Name = "buttonCancel";
+            this.buttonCancel.Size = new System.Drawing.Size(75, 23);
+            this.buttonCancel.TabIndex = 3;
+            this.buttonCancel.Text = "Cancel";
+            this.buttonCancel.UseVisualStyleBackColor = true;
+            this.buttonCancel.Click += new System.EventHandler(this.buttonCancel_Click);
+            // 
+            // TextInput
+            // 
+            this.AcceptButton = this.buttonOk;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.buttonCancel;
+            this.ClientSize = new System.Drawing.Size(372, 93);
+            this.ControlBox = false;
+            this.Controls.Add(this.buttonCancel);
+            this.Controls.Add(this.buttonOk);
+            this.Controls.Add(this.textBox1);
+            this.Controls.Add(this.label1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Name = "TextInput";
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Save Party";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.TextBox textBox1;
+        private System.Windows.Forms.Button buttonOk;
+        private System.Windows.Forms.Button buttonCancel;
+    }
+}

--- a/client/UI/TextInput.cs
+++ b/client/UI/TextInput.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace FFRKInspector.UI
+{
+    public partial class TextInput : Form
+    {
+        public TextInput()
+        {
+            InitializeComponent();
+        }
+
+        public string Label
+        {
+            get
+            {
+                return label1.Text;
+            }
+
+            set
+            {
+                if (value == null)
+                {
+                    label1.Text = "";
+                }
+                else
+                {
+                    label1.Text = value.ToString();
+                }
+            }
+        }
+        
+        public string Value
+        {
+            get
+            {
+                return textBox1.Text;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    textBox1.Text = "";
+                }
+                else
+                {
+                    textBox1.Text = value.ToString();
+                }
+                
+            }
+
+        }
+        
+        private void buttonOk_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.Close();
+        }
+
+        private void buttonCancel_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.Close();
+        }
+    }
+}

--- a/client/UI/TextInput.resx
+++ b/client/UI/TextInput.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
This replaces the equipment dropdowns with an equipment selector grid. 
<img width="1227" alt="screen shot 2016-04-22 at 1 31 46 pm" src="https://cloud.githubusercontent.com/assets/293433/14762553/519daa0c-094b-11e6-9fcf-d02f0ae79751.png">

Additionally, this adds the ability to save/load parties by reading/writing a JSON file in the directory of the DLLs.
